### PR TITLE
Change resource id to usize and make SystemData functions receive resource id

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,10 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .add(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();
-    resources.add(ResA, ());
-    resources.add(ResB, ());
+    resources.add(ResA);
+    resources.add(ResB);
 
-    // We can even pass a context,
-    // but we don't need one here
-    // so we pass `()`.
-    dispatcher.dispatch(&mut resources, ());
+    dispatcher.dispatch(&mut resources);
 }
 ```
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -185,12 +185,12 @@ fn basic(b: &mut Bencher) {
 
     pos.data[0] = Pos(Vec3::new(-5.0, -5.0, -5.0));
 
-    res.add(DeltaTime(0.05), ());
-    res.add(mass, ());
-    res.add(pos, ());
-    res.add(vel, ());
-    res.add(force, ());
-    res.add(spring, ());
+    res.add(DeltaTime(0.05), 0);
+    res.add(mass, 0);
+    res.add(pos, 0);
+    res.add(vel, 0);
+    res.add(force, 0);
+    res.add(spring, 0);
 
     b.iter(|| dispatcher.dispatch(&mut res));
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -185,12 +185,12 @@ fn basic(b: &mut Bencher) {
 
     pos.data[0] = Pos(Vec3::new(-5.0, -5.0, -5.0));
 
-    res.add(DeltaTime(0.05), 0);
-    res.add(mass, 0);
-    res.add(pos, 0);
-    res.add(vel, 0);
-    res.add(force, 0);
-    res.add(spring, 0);
+    res.add(DeltaTime(0.05));
+    res.add(mass);
+    res.add(pos);
+    res.add(vel);
+    res.add(force);
+    res.add(spring);
 
     b.iter(|| dispatcher.dispatch(&mut res));
 }

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -32,8 +32,5 @@ fn main() {
     resources.add(ResA);
     resources.add(ResB);
 
-    // We can even pass a context,
-    // but we don't need one here
-    // so we pass `()`.
     dispatcher.dispatch(&mut resources);
 }

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -29,8 +29,8 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .add(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();
-    resources.add(ResA, 0);
-    resources.add(ResB, 0);
+    resources.add(ResA);
+    resources.add(ResB);
 
     // We can even pass a context,
     // but we don't need one here

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -29,8 +29,8 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .add(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();
-    resources.add(ResA, ());
-    resources.add(ResB, ());
+    resources.add(ResA, 0);
+    resources.add(ResB, 0);
 
     // We can even pass a context,
     // but we don't need one here

--- a/examples/custom_bundle.rs
+++ b/examples/custom_bundle.rs
@@ -14,32 +14,31 @@ struct ExampleBundle<'a> {
 }
 
 impl<'a> SystemData<'a> for ExampleBundle<'a> {
-    fn fetch(res: &'a Resources) -> Self {
+    fn fetch(res: &'a Resources, id: usize) -> Self {
         ExampleBundle {
-            a: res.fetch(()),
-            b: res.fetch_mut(()),
+            a: res.fetch(id),
+            b: res.fetch_mut(id),
         }
     }
 
-    unsafe fn reads() -> Vec<ResourceId> {
-        vec![ResourceId::new::<ResA>()]
+    unsafe fn reads(id: usize) -> Vec<ResourceId> {
+        vec![ResourceId::new_with_id::<ResA>(id)]
     }
 
-    unsafe fn writes() -> Vec<ResourceId> {
-        vec![ResourceId::new::<ResB>()]
+    unsafe fn writes(id: usize) -> Vec<ResourceId> {
+        vec![ResourceId::new_with_id::<ResB>(id)]
     }
 }
 
 fn main() {
     let mut res = Resources::new();
-    res.add(ResA, ());
-    res.add(ResB, ());
+    res.add(ResA, 0);
+    res.add(ResB, 0);
 
 
-    let mut bundle = ExampleBundle::fetch(&res);
+    let mut bundle = ExampleBundle::fetch(&res, 0);
     *bundle.b = ResB;
 
     println!("{:?}", *bundle.a);
     println!("{:?}", *bundle.b);
-
 }

--- a/examples/custom_bundle.rs
+++ b/examples/custom_bundle.rs
@@ -32,8 +32,8 @@ impl<'a> SystemData<'a> for ExampleBundle<'a> {
 
 fn main() {
     let mut res = Resources::new();
-    res.add(ResA, 0);
-    res.add(ResB, 0);
+    res.add(ResA);
+    res.add(ResB);
 
 
     let mut bundle = ExampleBundle::fetch(&res, 0);

--- a/examples/derive_bundle.rs
+++ b/examples/derive_bundle.rs
@@ -24,8 +24,8 @@ struct Nested<'a> {
 
 fn main() {
     let mut res = Resources::new();
-    res.add(ResA, 0);
-    res.add(ResB, 0);
+    res.add(ResA);
+    res.add(ResB);
 
 
     {

--- a/examples/derive_bundle.rs
+++ b/examples/derive_bundle.rs
@@ -24,12 +24,12 @@ struct Nested<'a> {
 
 fn main() {
     let mut res = Resources::new();
-    res.add(ResA, ());
-    res.add(ResB, ());
+    res.add(ResA, 0);
+    res.add(ResB, 0);
 
 
     {
-        let mut bundle = AutoBundle::fetch(&res);
+        let mut bundle = AutoBundle::fetch(&res, 0);
 
         *bundle.b = ResB;
 
@@ -38,7 +38,7 @@ fn main() {
     }
 
     {
-        let nested = Nested::fetch(&res);
+        let nested = Nested::fetch(&res, 0);
 
         println!("a: {:?}", *nested.inner.a);
     }

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -32,8 +32,8 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .add(EmptySystem, "empty", &[])
         .build();
-    resources.add(ResA, ());
-    resources.add(ResB, ());
+    resources.add(ResA, 0);
+    resources.add(ResB, 0);
 
     dispatcher.dispatch_seq(&mut resources);
 }

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -32,8 +32,8 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .add(EmptySystem, "empty", &[])
         .build();
-    resources.add(ResA, 0);
-    resources.add(ResB, 0);
+    resources.add(ResA);
+    resources.add(ResB);
 
     dispatcher.dispatch_seq(&mut resources);
 }

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -34,8 +34,8 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .add_thread_local(EmptySystem(&mut x))
         .build();
-    resources.add(ResA, ());
-    resources.add(ResB, ());
+    resources.add(ResA, 0);
+    resources.add(ResB, 0);
 
     dispatcher.dispatch(&mut resources);
 }

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -34,8 +34,8 @@ fn main() {
     let mut dispatcher = DispatcherBuilder::new()
         .add_thread_local(EmptySystem(&mut x))
         .build();
-    resources.add(ResA, 0);
-    resources.add(ResB, 0);
+    resources.add(ResA);
+    resources.add(ResB);
 
     dispatcher.dispatch(&mut resources);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@
 //!     let mut dispatcher = DispatcherBuilder::new()
 //!         .add(EmptySystem, "empty", &[])
 //!         .build();
-//!     resources.add(ResA, 0);
-//!     resources.add(ResB, 0);
+//!     resources.add(ResA);
+//!     resources.add(ResB);
 //!
 //!     dispatcher.dispatch(&mut resources);
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@
 //!     let mut dispatcher = DispatcherBuilder::new()
 //!         .add(EmptySystem, "empty", &[])
 //!         .build();
-//!     resources.add(ResA, ());
-//!     resources.add(ResB, ());
+//!     resources.add(ResA, 0);
+//!     resources.add(ResB, 0);
 //!
 //!     dispatcher.dispatch(&mut resources);
 //! }

--- a/src/res.rs
+++ b/src/res.rs
@@ -180,6 +180,9 @@ impl Resources {
 
     /// Adds a new resource to this container.
     ///
+    /// This method calls `add_with_id` with
+    /// 0 for the id.
+    ///
     /// # Panics
     ///
     /// Panics if the resource is already registered.
@@ -203,9 +206,15 @@ impl Resources {
     /// use shred::Resources;
     ///
     /// let mut res = Resources::new();
-    /// res.add(MyRes(5), 0);
+    /// res.add(MyRes(5));
     /// ```
-    pub fn add<R>(&mut self, r: R, id: usize)
+    pub fn add<R>(&mut self, r: R) where R: Resource {
+        self.add_with_id(r, 0)
+    }
+
+    /// Like `add()`, but allows specifying
+    /// and id while `add()` assumes `0`.
+    pub fn add_with_id<R>(&mut self, r: R, id: usize)
         where R: Resource
     {
         use std::collections::hash_map::Entry;

--- a/src/res.rs
+++ b/src/res.rs
@@ -133,9 +133,9 @@ impl<T> Resource for T where T: Any + Send + Sync {}
 
 /// The id of a [`Resource`],
 /// which is a tuple struct with a type
-/// id and a component id (represented with a `usize`).
+/// id and an additional resource id (represented with a `usize`).
 ///
-/// The default component id is `0`.
+/// The default resource id is `0`.
 ///
 /// [`Resource`]: trait.Resource.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/system.rs
+++ b/src/system.rs
@@ -32,7 +32,7 @@ pub trait SystemData<'a> {
     /// returned from `reads` / `writes`!
     ///
     /// [`Resources`]: trait.Resources.html
-    fn fetch(res: &'a Resources) -> Self;
+    fn fetch(res: &'a Resources, id: usize) -> Self;
 
     /// A list of [`ResourceId`]s the bundle
     /// needs read access to in order to
@@ -47,7 +47,7 @@ pub trait SystemData<'a> {
     /// This method is only executed once,
     /// thus the returned value may never change
     /// (otherwise it has no effect).
-    unsafe fn reads() -> Vec<ResourceId>;
+    unsafe fn reads(id: usize) -> Vec<ResourceId>;
 
     /// A list of [`ResourceId`]s the bundle
     /// needs write access to in order to
@@ -62,7 +62,7 @@ pub trait SystemData<'a> {
     /// This method is only executed once,
     /// thus the returned value may never change
     /// (otherwise it has no effect).
-    unsafe fn writes() -> Vec<ResourceId>;
+    unsafe fn writes(id: usize) -> Vec<ResourceId>;
 }
 
 macro_rules! impl_data {
@@ -70,32 +70,32 @@ macro_rules! impl_data {
         impl<'a, $($ty),*> SystemData<'a> for ( $( $ty , )* )
             where $( $ty : SystemData<'a> ),*
         {
-            fn fetch(res: &'a Resources) -> Self {
+            fn fetch(res: &'a Resources, id: usize) -> Self {
                 #![allow(unused_variables)]
 
-                ( $( <$ty as SystemData<'a>>::fetch(res), )* )
+                ( $( <$ty as SystemData<'a>>::fetch(res, id.clone()), )* )
             }
 
-            unsafe fn reads() -> Vec<ResourceId> {
+            unsafe fn reads(id: usize) -> Vec<ResourceId> {
                 #![allow(unused_mut)]
 
                 let mut r = Vec::new();
 
                 $( {
-                        let mut reads = <$ty as SystemData>::reads();
+                        let mut reads = <$ty as SystemData>::reads(id.clone());
                         r.append(&mut reads);
                     } )*
 
                 r
             }
 
-            unsafe fn writes() -> Vec<ResourceId> {
+            unsafe fn writes(id: usize) -> Vec<ResourceId> {
                 #![allow(unused_mut)]
 
                 let mut r = Vec::new();
 
                 $( {
-                        let mut writes = <$ty as SystemData>::writes();
+                        let mut writes = <$ty as SystemData>::writes(id.clone());
                         r.append(&mut writes);
                     } )*
 
@@ -106,15 +106,15 @@ macro_rules! impl_data {
 }
 
 impl<'a> SystemData<'a> for () {
-    fn fetch(_: &'a Resources) -> Self {
+    fn fetch(_: &'a Resources, _: usize) -> Self {
         ()
     }
 
-    unsafe fn reads() -> Vec<ResourceId> {
+    unsafe fn reads(_: usize) -> Vec<ResourceId> {
         Vec::new()
     }
 
-    unsafe fn writes() -> Vec<ResourceId> {
+    unsafe fn writes(_: usize) -> Vec<ResourceId> {
         Vec::new()
     }
 }

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -54,7 +54,7 @@ fn dispatch_builder_invalid() {
 #[test]
 fn dispatch_basic() {
     let mut res = Resources::new();
-    res.add(Res, 0);
+    res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySys, "a", &[])
@@ -67,7 +67,7 @@ fn dispatch_basic() {
 #[test]
 fn dispatch_rw_block() {
     let mut res = Resources::new();
-    res.add(Res, 0);
+    res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySys, "a", &[])
@@ -80,7 +80,7 @@ fn dispatch_rw_block() {
 #[test]
 fn dispatch_rw_block_rev() {
     let mut res = Resources::new();
-    res.add(Res, 0);
+    res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
@@ -93,7 +93,7 @@ fn dispatch_rw_block_rev() {
 #[test]
 fn dispatch_sequential() {
     let mut res = Resources::new();
-    res.add(Res, 0);
+    res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
@@ -107,7 +107,7 @@ fn dispatch_sequential() {
 #[test]
 fn dispatch_async() {
     let mut res = Resources::new();
-    res.add(Res, 0);
+    res.add(Res);
 
     let mut d = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
@@ -123,7 +123,7 @@ fn dispatch_async() {
 #[test]
 fn dispatch_async_res() {
     let mut res = Resources::new();
-    res.add(Res, 0);
+    res.add(Res);
 
     let mut d = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
@@ -133,5 +133,5 @@ fn dispatch_async_res() {
     d.dispatch();
 
     let res = d.mut_res();
-    res.add(Res, 2);
+    res.add_with_id(Res, 2);
 }

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -54,7 +54,7 @@ fn dispatch_builder_invalid() {
 #[test]
 fn dispatch_basic() {
     let mut res = Resources::new();
-    res.add(Res, ());
+    res.add(Res, 0);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySys, "a", &[])
@@ -67,7 +67,7 @@ fn dispatch_basic() {
 #[test]
 fn dispatch_rw_block() {
     let mut res = Resources::new();
-    res.add(Res, ());
+    res.add(Res, 0);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySys, "a", &[])
@@ -80,7 +80,7 @@ fn dispatch_rw_block() {
 #[test]
 fn dispatch_rw_block_rev() {
     let mut res = Resources::new();
-    res.add(Res, ());
+    res.add(Res, 0);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
@@ -93,7 +93,7 @@ fn dispatch_rw_block_rev() {
 #[test]
 fn dispatch_sequential() {
     let mut res = Resources::new();
-    res.add(Res, ());
+    res.add(Res, 0);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
@@ -107,7 +107,7 @@ fn dispatch_sequential() {
 #[test]
 fn dispatch_async() {
     let mut res = Resources::new();
-    res.add(Res, ());
+    res.add(Res, 0);
 
     let mut d = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
@@ -123,7 +123,7 @@ fn dispatch_async() {
 #[test]
 fn dispatch_async_res() {
     let mut res = Resources::new();
-    res.add(Res, ());
+    res.add(Res, 0);
 
     let mut d = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])


### PR DESCRIPTION
Using `usize` for ids has several advantages:

* Easier to implement than hashed values because I only need to accept `usize`, no need for two variants (`Hash`-implementor and hashed value)
* No collisions of ids

---

Accepting the additional ids allows to actually have different system data for every id.