### PR TITLE
Remove unsafe marker from SystemData functions

### DIFF
--- a/examples/custom_bundle.rs
+++ b/examples/custom_bundle.rs
@@ -21,11 +21,11 @@ impl<'a> SystemData<'a> for ExampleBundle<'a> {
         }
     }
 
-    unsafe fn reads(id: usize) -> Vec<ResourceId> {
+    fn reads(id: usize) -> Vec<ResourceId> {
         vec![ResourceId::new_with_id::<ResA>(id)]
     }
 
-    unsafe fn writes(id: usize) -> Vec<ResourceId> {
+    fn writes(id: usize) -> Vec<ResourceId> {
         vec![ResourceId::new_with_id::<ResB>(id)]
     }
 }

--- a/shred-derive/src/lib.rs
+++ b/shred-derive/src/lib.rs
@@ -50,7 +50,7 @@ fn impl_system_data(ast: &MacroInput) -> Tokens {
                 #fetch_return
             }
 
-            unsafe fn reads(id: usize) -> Vec<::shred::ResourceId> {
+            fn reads(id: usize) -> Vec<::shred::ResourceId> {
                 let mut r = Vec::new();
 
                 #( {
@@ -61,7 +61,7 @@ fn impl_system_data(ast: &MacroInput) -> Tokens {
                 r
             }
 
-            unsafe fn writes(id: usize) -> Vec<::shred::ResourceId> {
+            fn writes(id: usize) -> Vec<::shred::ResourceId> {
                 let mut r = Vec::new();
 
                 #( {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -450,8 +450,8 @@ impl<'t> DispatcherBuilder<'t> {
         where T: for<'a> System<'a> + Send + 't
     {
         let id = self.systems.len();
-        let reads = unsafe { T::SystemData::reads(data_id) };
-        let writes = unsafe { T::SystemData::writes(data_id) };
+        let reads = T::SystemData::reads(data_id);
+        let writes = T::SystemData::writes(data_id);
 
         let dependencies: Vec<usize> = dep.iter()
             .map(|x| {

--- a/src/res.rs
+++ b/src/res.rs
@@ -35,11 +35,11 @@ impl<'a, T> SystemData<'a> for Fetch<'a, T>
         res.fetch(id)
     }
 
-    unsafe fn reads(id: usize) -> Vec<ResourceId> {
+    fn reads(id: usize) -> Vec<ResourceId> {
         vec![ResourceId::new_with_id::<T>(id)]
     }
 
-    unsafe fn writes(_: usize) -> Vec<ResourceId> {
+    fn writes(_: usize) -> Vec<ResourceId> {
         vec![]
     }
 }
@@ -113,11 +113,11 @@ impl<'a, T> SystemData<'a> for FetchMut<'a, T>
         res.fetch_mut(id)
     }
 
-    unsafe fn reads(_: usize) -> Vec<ResourceId> {
+    fn reads(_: usize) -> Vec<ResourceId> {
         vec![]
     }
 
-    unsafe fn writes(id: usize) -> Vec<ResourceId> {
+    fn writes(id: usize) -> Vec<ResourceId> {
         vec![ResourceId::new_with_id::<T>(id)]
     }
 }
@@ -311,9 +311,9 @@ mod tests {
 
     #[test]
     fn fetch_aspects() {
-        assert_eq!(unsafe { Fetch::<Res>::reads(4) },
+        assert_eq!(Fetch::<Res>::reads(4),
                    vec![ResourceId::new_with_id::<Res>(4)]);
-        assert_eq!(unsafe { Fetch::<Res>::writes(8) }, vec![]);
+        assert_eq!(Fetch::<Res>::writes(8), vec![]);
 
         let mut res = Resources::new();
         res.add_with_id(Res, 56);
@@ -322,8 +322,8 @@ mod tests {
 
     #[test]
     fn fetch_mut_aspects() {
-        assert_eq!(unsafe { FetchMut::<Res>::reads(4) }, vec![]);
-        assert_eq!(unsafe { FetchMut::<Res>::writes(8) },
+        assert_eq!(FetchMut::<Res>::reads(4), vec![]);
+        assert_eq!(FetchMut::<Res>::writes(8),
                    vec![ResourceId::new_with_id::<Res>(8)]);
 
         let mut res = Resources::new();

--- a/src/system.rs
+++ b/src/system.rs
@@ -47,7 +47,7 @@ pub trait SystemData<'a> {
     /// This method is only executed once,
     /// thus the returned value may never change
     /// (otherwise it has no effect).
-    unsafe fn reads(id: usize) -> Vec<ResourceId>;
+    fn reads(id: usize) -> Vec<ResourceId>;
 
     /// A list of [`ResourceId`]s the bundle
     /// needs write access to in order to
@@ -62,7 +62,7 @@ pub trait SystemData<'a> {
     /// This method is only executed once,
     /// thus the returned value may never change
     /// (otherwise it has no effect).
-    unsafe fn writes(id: usize) -> Vec<ResourceId>;
+    fn writes(id: usize) -> Vec<ResourceId>;
 }
 
 macro_rules! impl_data {
@@ -76,7 +76,7 @@ macro_rules! impl_data {
                 ( $( <$ty as SystemData<'a>>::fetch(res, id.clone()), )* )
             }
 
-            unsafe fn reads(id: usize) -> Vec<ResourceId> {
+            fn reads(id: usize) -> Vec<ResourceId> {
                 #![allow(unused_mut)]
 
                 let mut r = Vec::new();
@@ -89,7 +89,7 @@ macro_rules! impl_data {
                 r
             }
 
-            unsafe fn writes(id: usize) -> Vec<ResourceId> {
+            fn writes(id: usize) -> Vec<ResourceId> {
                 #![allow(unused_mut)]
 
                 let mut r = Vec::new();
@@ -110,11 +110,11 @@ impl<'a> SystemData<'a> for () {
         ()
     }
 
-    unsafe fn reads(_: usize) -> Vec<ResourceId> {
+    fn reads(_: usize) -> Vec<ResourceId> {
         Vec::new()
     }
 
-    unsafe fn writes(_: usize) -> Vec<ResourceId> {
+    fn writes(_: usize) -> Vec<ResourceId> {
         Vec::new()
     }
 }


### PR DESCRIPTION
This isn't necessary anymore, cannot cause undefined behavior. Using it wrong causes the thread to panic.