### PR TITLE
Panic if multiple systems with same name are registered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["torkleyy"]
 description = """
 Dispatches systems in parallel which need read access to some resources,


### PR DESCRIPTION
Allows `""` to be used in case you don't need a name.

r? @WaDelma
