### PR TITLE
Include name of system that was not found in panic message

### DIFF
--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -90,7 +90,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
         let id = self.next_id();
 
         let dependencies = dep.iter()
-            .map(|x| *self.map.get(*x).expect("No such system registered"))
+            .map(|x| *self.map.get(*x).expect(&format!("No such system registered (\"{}\")", *x)))
             .collect();
 
         if name != "" {


### PR DESCRIPTION
I have run into this error many times and it's not fun to find the source using `RUST_BACKTRACE`. This should help find the cause of the error quicker and more easily.