### PR TITLE
Fix bug with chained dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["torkleyy <torkleyy@gmail.com>"]
 description = """
 Dispatches systems in parallel which need read access to some resources,


### PR DESCRIPTION
Previously, the depdendency chain

```
A <- B <- C
```

could only be specified by adding an additional
dependency from C to A. Otherwise, it would give you

```
A <-- C
B
```

in the dispatcher.

Fixes slide-rs/specs#253