### PR TITLE
Add Par, Seq, ParSeq, par! and seq!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rust:
 - beta
 - stable
 - 1.17.0
+env:
+  global:
+    - RUST_MIN_STACK=16777216
 branches:
   only:
     - staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ rust:
 - beta
 - stable
 - 1.17.0
-env:
-  global:
-    - RUST_MIN_STACK=16777216
 branches:
   only:
     - staging

--- a/examples/par_seq.rs
+++ b/examples/par_seq.rs
@@ -1,0 +1,64 @@
+extern crate rayon;
+#[macro_use(par, seq)]
+extern crate shred;
+
+use rayon::ThreadPool;
+
+use shred::{ParSeq, Resources, System};
+
+macro_rules! impl_sys {
+    ($( $id:ident )*) => {
+        $(
+            impl<'a> ::shred::System<'a> for $id {
+                type SystemData = ();
+                fn run(&mut self, _: Self::SystemData) {
+                    println!(stringify!($id));
+                }
+            }
+        )*
+    };
+}
+
+struct SysA;
+struct SysB;
+struct SysC;
+struct SysD;
+struct SysWithLifetime<'a>(&'a u8);
+struct SysLocal(*const u8);
+
+impl_sys!(SysA SysB SysC SysD SysLocal);
+
+impl<'a, 'b> System<'a> for SysWithLifetime<'b> {
+    type SystemData = ();
+
+    fn run(&mut self, _: Self::SystemData) {
+        println!("SysWithLifetime");
+    }
+}
+
+fn main() {
+    #![cfg_attr(rustfmt, rustfmt_skip)]
+
+    let pool = ThreadPool::new(Default::default()).unwrap();
+
+    let mut res = Resources::new();
+    let x = 5u8;
+
+    let mut dispatcher = ParSeq::new(
+        seq![
+            par![
+                SysA,
+                SysWithLifetime(&x),
+                seq![
+                    SysC,
+                    SysD,
+                ],
+            ],
+            SysB,
+            SysLocal(&x as *const u8),
+        ],
+        &pool,
+    );
+
+    dispatcher.dispatch(&mut res);
+}

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -170,10 +170,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
         );
 
         #[cfg(target_os = "emscripten")]
-        let d = new_dispatcher(
-            self.stages_builder.build(),
-            self.thread_local,
-        );
+        let d = new_dispatcher(self.stages_builder.build(), self.thread_local);
 
         d
     }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2,9 +2,11 @@
 pub use self::async::AsyncDispatcher;
 pub use self::builder::DispatcherBuilder;
 pub use self::dispatcher::Dispatcher;
+pub use self::par_seq::{Par, ParSeq, Seq};
 
 #[cfg(not(target_os = "emscripten"))]
 mod async;
 mod builder;
 mod dispatcher;
+mod par_seq;
 mod stage;

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -10,3 +10,4 @@ mod builder;
 mod dispatcher;
 mod par_seq;
 mod stage;
+mod util;

--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -132,7 +132,7 @@ impl<H> Par<H, Nil> {
 /// ## Thread-local systems
 ///
 /// This dispatcher also allows more freedom
-/// for thread-local systems; you cannot execute wherever you want,
+/// for thread-local systems; you can execute wherever you want,
 /// just not in parallel with other systems (putting one inside
 /// `par!` will give you a compile-time error saying the `Send` requirement
 /// is unmet).
@@ -219,7 +219,7 @@ where
     }
 
     /// Dispatches the systems using `res`.
-    /// This involves zero virtual cost.
+    /// This doesn't call any virtual functions.
     pub fn dispatch(&mut self, res: &mut Resources) {
         self.run.run(res, self.pool.borrow());
     }

--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -104,6 +104,21 @@ impl<H> Par<H, Nil> {
 /// A dispatcher intended to be used with
 /// `Par` and `Seq`  structures.
 ///
+/// This is more flexible and performant than `Dispatcher`,
+/// however, you have to check conflicts yourself.
+/// That means you cannot run two systems in parallel
+/// which write to the same resource; if you'd do that,
+/// one of the systems will panic while trying to fetch
+/// the `SystemData`.
+///
+/// ## Thread-local systems
+///
+/// This dispatcher also allows more freedom
+/// for thread-local systems; you cannot execute wherever you want,
+/// just not in parallel with other systems (putting one inside
+/// `par!` will give you a compile-time error saying the `Send` requirement
+/// is unmet).
+///
 /// ## Examples
 ///
 /// ```

--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -1,0 +1,319 @@
+use std::borrow::Borrow;
+
+use res::Resources;
+use system::RunNow;
+use system::System;
+
+use rayon::ThreadPool;
+
+pub struct Nil;
+
+/// The `par!` macro may be used to easily create a structure
+/// which runs things in parallel.
+///
+/// ## Examples
+///
+/// ```
+/// #[macro_use(par)]
+/// extern crate shred;
+///
+/// # struct SysA;
+/// # struct SysB;
+/// # struct SysC;
+/// # fn main() {
+/// par![
+///     SysA,
+///     SysB,
+///     SysC,
+/// ]
+/// # ;}
+/// ```
+#[macro_export]
+macro_rules! par {
+    ($head:expr, $( $tail:expr ,)+) => {
+        {
+            $crate::Par::new($head)
+                $( .with($tail) )*
+        }
+    };
+}
+
+/// The `seq!` macro may be used to easily create a structure
+/// which runs things sequentially.
+///
+/// ## Examples
+///
+/// ```
+/// #[macro_use(seq)]
+/// extern crate shred;
+///
+/// # struct SysA;
+/// # struct SysB;
+/// # struct SysC;
+/// # fn main() {
+/// seq![
+///     SysA,
+///     SysB,
+///     SysC,
+/// ]
+/// # ;}
+/// ```
+#[macro_export]
+macro_rules! seq {
+    ($head:expr, $( $tail:expr ,)+) => {
+        {
+            $crate::Seq::new($head)
+                $( .with($tail) )*
+        }
+    };
+}
+
+impl<'a> System<'a> for Nil {
+    type SystemData = ();
+
+    fn run(&mut self, _: Self::SystemData) {}
+}
+
+/// Runs two tasks in parallel.
+/// These two tasks are called `head` and `tail`
+/// in the following documentation.
+pub struct Par<H, T> {
+    head: H,
+    tail: T,
+}
+
+impl<H> Par<H, Nil> {
+    /// Creates a new `Par` struct, with the tail being a no-op.
+    pub fn new(head: H) -> Self {
+        Par { head, tail: Nil }
+    }
+
+    /// Adds `sys` as the second job and returns a new `Par` struct
+    /// with the previous struct as head and a no-op tail.
+    pub fn with<T>(self, sys: T) -> Par<Par<H, T>, Nil> {
+        Par {
+            head: Par {
+                head: self.head,
+                tail: sys,
+            },
+            tail: Nil,
+        }
+    }
+}
+
+/// A dispatcher intended to be used with
+/// `Par` and `Seq`  structures.
+///
+/// ## Examples
+///
+/// ```
+/// # extern crate rayon;
+/// #[macro_use(par, seq)]
+/// extern crate shred;
+///
+/// # use rayon::ThreadPool;
+/// #
+/// # use shred::{ParSeq, Resources, System};
+/// #
+/// # macro_rules! impl_sys {
+/// #     ($( $id:ident )*) => {
+/// #         $(
+/// #             impl<'a> ::shred::System<'a> for $id {
+/// #                 type SystemData = ();
+/// #                 fn run(&mut self, _: Self::SystemData) {}
+/// #             }
+/// #         )*
+/// #     };
+/// # }
+/// #
+/// # struct SysA;
+/// # struct SysB;
+/// # struct SysC;
+/// # struct SysD;
+/// # struct SysWithLifetime<'a>(&'a u8);
+/// # struct SysLocal(*const u8);
+/// #
+/// # impl_sys!(SysA SysB SysC SysD SysLocal);
+/// #
+/// # impl<'a, 'b> System<'a> for SysWithLifetime<'b> {
+/// #     type SystemData = ();
+/// #
+/// #     fn run(&mut self, _: Self::SystemData) {}
+/// # }
+///
+/// # fn main() {
+/// # #![cfg_attr(rustfmt, rustfmt_skip)]
+/// #
+/// # let pool = ThreadPool::new(Default::default()).unwrap();
+/// #
+/// # let mut res = Resources::new();
+/// let x = 5u8;
+///
+/// let mut dispatcher = ParSeq::new(
+///     seq![
+///         par![
+///             SysA,
+///             SysWithLifetime(&x),
+///             seq![
+///                 SysC,
+///                 SysD,
+///             ],
+///         ],
+///         SysB,
+///         SysLocal(&x as *const u8),
+///     ],
+///     &pool,
+/// );
+///
+/// dispatcher.dispatch(&mut res);
+/// # }
+/// ```
+pub struct ParSeq<P, T> {
+    run: T,
+    pool: P,
+}
+
+impl<P, T> ParSeq<P, T>
+where
+    P: Borrow<ThreadPool>,
+    T: for<'a> RunWithPool<'a>,
+{
+    /// Creates a new `ParSeq` dispatcher.
+    /// `run` is usually created by using the `par!` / `seq!`
+    /// macros.
+    pub fn new(run: T, pool: P) -> Self {
+        ParSeq { run, pool }
+    }
+
+    /// Dispatches the systems using `res`.
+    /// This involves zero virtual cost.
+    pub fn dispatch(&mut self, res: &mut Resources) {
+        self.run.run(res, self.pool.borrow());
+    }
+}
+
+pub trait RunWithPool<'a> {
+    fn run(&mut self, res: &'a Resources, pool: &ThreadPool);
+}
+
+impl<'a, T> RunWithPool<'a> for T
+where
+    T: System<'a>,
+{
+    fn run(&mut self, res: &'a Resources, _: &ThreadPool) {
+        RunNow::run_now(self, res);
+    }
+}
+
+impl<'a, H, T> RunWithPool<'a> for Par<H, T>
+where
+    H: RunWithPool<'a> + Send,
+    T: RunWithPool<'a> + Send,
+{
+    fn run(&mut self, res: &'a Resources, pool: &ThreadPool) {
+        let head = &mut self.head;
+        let tail = &mut self.tail;
+
+        pool.scope(move |s| {
+            s.spawn(move |_| head.run(res, pool));
+            s.spawn(move |_| tail.run(res, pool));
+        });
+    }
+}
+
+/// Runs two tasks sequentially.
+/// These two tasks are called `head` and `tail`
+/// in the following documentation.
+pub struct Seq<H, T> {
+    head: H,
+    tail: T,
+}
+
+impl<H> Seq<H, Nil> {
+    /// Creates a new `Seq` struct, with the tail being a no-op.
+    pub fn new(head: H) -> Self {
+        Seq { head, tail: Nil }
+    }
+
+    /// Adds `sys` as the second job and returns a new `Seq` struct
+    /// with the previous struct as head and a no-op tail.
+    pub fn with<T>(self, sys: T) -> Seq<Seq<H, T>, Nil> {
+        Seq {
+            head: Seq {
+                head: self.head,
+                tail: sys,
+            },
+            tail: Nil,
+        }
+    }
+}
+
+impl<'a, H, T> RunWithPool<'a> for Seq<H, T>
+where
+    H: RunWithPool<'a>,
+    T: RunWithPool<'a>,
+{
+    fn run(&mut self, res: &'a Resources, pool: &ThreadPool) {
+        self.head.run(res, pool);
+        self.tail.run(res, pool);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::*;
+
+    #[test]
+    fn build_par() {
+        let pool = ThreadPool::new(Default::default()).unwrap();
+
+        struct A(Arc<AtomicUsize>);
+
+        impl<'a> System<'a> for A {
+            type SystemData = ();
+
+            fn run(&mut self, _: Self::SystemData) {
+                self.0.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+
+        let nr = Arc::new(AtomicUsize::new(0));
+
+        Par::new(A(nr.clone()))
+            .with(A(nr.clone()))
+            .with(A(nr.clone()))
+            .run(&Resources::new(), &pool);
+
+        assert_eq!(nr.load(Ordering::Acquire), 3);
+
+        par![A(nr.clone()), A(nr.clone()),].run(&Resources::new(), &pool);
+
+        assert_eq!(nr.load(Ordering::Acquire), 5);
+    }
+
+    #[test]
+    fn build_seq() {
+        let pool = ThreadPool::new(Default::default()).unwrap();
+
+        struct A(Arc<AtomicUsize>);
+
+        impl<'a> System<'a> for A {
+            type SystemData = ();
+
+            fn run(&mut self, _: Self::SystemData) {
+                self.0.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+
+        let nr = Arc::new(AtomicUsize::new(0));
+
+        Seq::new(A(nr.clone()))
+            .with(A(nr.clone()))
+            .with(A(nr.clone()))
+            .run(&Resources::new(), &pool);
+
+        assert_eq!(nr.load(Ordering::Acquire), 3);
+    }
+}

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -34,6 +34,7 @@ use arrayvec::ArrayVec;
 use smallvec::SmallVec;
 
 use dispatch::dispatcher::{SystemExecSend, SystemId};
+use dispatch::util::check_intersection;
 use res::{ResourceId, Resources};
 use system::{RunningTime, System};
 
@@ -295,15 +296,6 @@ impl<'a> StagesBuilder<'a> {
             }
         }
     }
-}
-
-fn check_intersection<'i, 'j, T, I, J>(mut i: I, j: J) -> bool
-where
-    I: Iterator<Item = &'i T>,
-    J: Iterator<Item = &'j T> + Clone,
-    T: PartialEq + 'i + 'j,
-{
-    i.any(|elem_i| j.clone().any(|elem_j| *elem_j == *elem_i))
 }
 
 #[cfg(test)]

--- a/src/dispatch/util.rs
+++ b/src/dispatch/util.rs
@@ -1,0 +1,8 @@
+pub fn check_intersection<'i, 'j, T, I, J>(mut i: I, j: J) -> bool
+where
+    I: Iterator<Item = &'i T>,
+    J: Iterator<Item = &'j T> + Clone,
+    T: PartialEq + 'i + 'j,
+{
+    i.any(|elem_i| j.clone().any(|elem_j| *elem_j == *elem_i))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,12 @@
 //! }
 //! ```
 //!
+//! Now, the above dispatcher is pretty easy to setup.
+//! There's also a more flexible and performant one;
+//! once you know about system data and parallelization,
+//! take a look at `ParSeq`, which allows dispatching with
+//! zero virtual calls.
+//!
 
 #![deny(unused_must_use)]
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod dispatch;
 mod res;
 mod system;
 
-pub use dispatch::{Dispatcher, DispatcherBuilder};
+pub use dispatch::{Dispatcher, DispatcherBuilder, Par, ParSeq, Seq};
 #[cfg(not(target_os = "emscripten"))]
 pub use dispatch::AsyncDispatcher;
 pub use res::{Fetch, FetchId, FetchIdMut, FetchMut, Resource, ResourceId, Resources};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,9 @@
 //! }
 //! ```
 //!
-//! Now, the above dispatcher is pretty easy to setup.
-//! There's also a more flexible and performant one;
-//! once you know about system data and parallelization,
-//! take a look at `ParSeq`, which allows dispatching with
-//! zero virtual calls.
+//! Once you are more familiar with how system data and parallelization works,
+//! you can take look at a more flexible and performant way to dispatch: `ParSeq`.
+//! Using it is bit trickier, but it allows dispatching without any virtual function calls.
 //!
 
 #![deny(unused_must_use)]


### PR DESCRIPTION
This allows dispatching with zero virtual calls and maximum flexibility.

### Example

```rust
let mut dispatcher = ParSeq::new(
    seq![
        par![
            SysA,
            SysWithLifetime(&x),
            seq![
                SysC,
                SysD,
            ],
        ],
        SysB,
        SysLocal(&x as *const u8),
    ],
    &pool,
);
```