### PR TITLE
Standardize builder naming

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -168,9 +168,9 @@ impl<'a> System<'a> for ClearForceAccum {
 #[bench]
 fn basic(b: &mut Bencher) {
     let mut dispatcher = DispatcherBuilder::new()
-        .add(SpringForce, "spring", &[])
-        .add(IntegrationSystem, "integration", &[])
-        .add(ClearForceAccum, "clear_force", &["integration"]) // clear_force is executed after
+        .with(SpringForce, "spring", &[])
+        .with(IntegrationSystem, "integration", &[])
+        .with(ClearForceAccum, "clear_force", &["integration"]) // clear_force is executed after
                                                                // the integration
         .build();
 

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -27,7 +27,7 @@ impl<'a> System<'a> for PrintSystem {
 fn main() {
     let mut resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
-        .add(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
+        .with(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();
     resources.add(ResA);
     resources.add(ResB);

--- a/examples/fetch_opt.rs
+++ b/examples/fetch_opt.rs
@@ -31,7 +31,7 @@ impl<'a> System<'a> for PrintSystem {
 fn main() {
     let mut resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
-        .add(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
+        .with(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();
     resources.add(ResA);
 

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -30,7 +30,7 @@ impl<'a> System<'a> for EmptySystem {
 fn main() {
     let mut resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
-        .add(EmptySystem, "empty", &[])
+        .with(EmptySystem, "empty", &[])
         .build();
     resources.add(ResA);
     resources.add(ResB);

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -32,7 +32,7 @@ fn main() {
 
     let mut resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
-        .add_thread_local(EmptySystem(&mut x))
+        .with_thread_local(EmptySystem(&mut x))
         .build();
     resources.add(ResA);
     resources.add(ResB);

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -152,13 +152,13 @@ mod tests {
 
     fn new_builder() -> DispatcherBuilder<'static, 'static> {
         DispatcherBuilder::new()
-            .add(Dummy(0), "0", &[])
-            .add(Dummy(1), "1", &[])
-            .add(Dummy(2), "2", &[])
-            .add(Dummy(3), "3", &["1"])
-            .add_barrier()
-            .add(Dummy(4), "4", &[])
-            .add(Dummy(5), "5", &["4"])
+            .with(Dummy(0), "0", &[])
+            .with(Dummy(1), "1", &[])
+            .with(Dummy(2), "2", &[])
+            .with(Dummy(3), "3", &["1"])
+            .with_barrier()
+            .with(Dummy(4), "4", &[])
+            .with(Dummy(5), "5", &["4"])
     }
 
     fn new_resources() -> Resources {
@@ -172,7 +172,7 @@ mod tests {
     #[should_panic(expected = "Propagated panic")]
     fn dispatcher_panics() {
         DispatcherBuilder::new()
-            .add(Panic, "p", &[])
+            .with(Panic, "p", &[])
             .build()
             .dispatch(&mut new_resources())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! fn main() {
 //!     let mut resources = Resources::new();
 //!     let mut dispatcher = DispatcherBuilder::new()
-//!         .add(EmptySystem, "empty", &[])
+//!         .with(EmptySystem, "empty", &[])
 //!         .build();
 //!     resources.add(ResA);
 //!     resources.add(ResB);

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -57,9 +57,9 @@ impl<'a, 'b> System<'a> for Whatever<'b> {
 #[test]
 fn dispatch_builder() {
     DispatcherBuilder::new()
-        .add(DummySys, "a", &[])
-        .add(DummySys, "b", &["a"])
-        .add(DummySys, "c", &["a"])
+        .with(DummySys, "a", &[])
+        .with(DummySys, "b", &["a"])
+        .with(DummySys, "c", &["a"])
         .build();
 }
 
@@ -67,8 +67,8 @@ fn dispatch_builder() {
 #[should_panic(expected = "No such system registered")]
 fn dispatch_builder_invalid() {
     DispatcherBuilder::new()
-        .add(DummySys, "a", &[])
-        .add(DummySys, "b", &["z"])
+        .with(DummySys, "a", &[])
+        .with(DummySys, "b", &["z"])
         .build();
 }
 
@@ -80,9 +80,9 @@ fn dispatch_basic() {
     let number = 5;
 
     let mut d: Dispatcher = DispatcherBuilder::new()
-        .add(DummySys, "a", &[])
-        .add(DummySys, "b", &["a"])
-        .add(Whatever(&number), "w", &[])
+        .with(DummySys, "a", &[])
+        .with(DummySys, "b", &["a"])
+        .with(Whatever(&number), "w", &[])
         .build();
 
     d.dispatch(&mut res);
@@ -94,8 +94,8 @@ fn dispatch_ww_block() {
     res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
-        .add(DummySysMut, "a", &[])
-        .add(DummySysMut, "b", &[])
+        .with(DummySysMut, "a", &[])
+        .with(DummySysMut, "b", &[])
         .build();
 
     d.dispatch(&mut res);
@@ -107,8 +107,8 @@ fn dispatch_rw_block() {
     res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
-        .add(DummySys, "a", &[])
-        .add(DummySysMut, "b", &[])
+        .with(DummySys, "a", &[])
+        .with(DummySysMut, "b", &[])
         .build();
 
     d.dispatch(&mut res);
@@ -120,8 +120,8 @@ fn dispatch_rw_block_rev() {
     res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
-        .add(DummySysMut, "a", &[])
-        .add(DummySys, "b", &[])
+        .with(DummySysMut, "a", &[])
+        .with(DummySys, "b", &[])
         .build();
 
     d.dispatch(&mut res);
@@ -133,8 +133,8 @@ fn dispatch_sequential() {
     res.add(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
-        .add(DummySysMut, "a", &[])
-        .add(DummySys, "b", &[])
+        .with(DummySysMut, "a", &[])
+        .with(DummySys, "b", &[])
         .build();
 
     d.dispatch_seq(&mut res);
@@ -147,8 +147,8 @@ fn dispatch_async() {
     res.add(Res);
 
     let mut d = DispatcherBuilder::new()
-        .add(DummySysMut, "a", &[])
-        .add(DummySys, "b", &[])
+        .with(DummySysMut, "a", &[])
+        .with(DummySys, "b", &[])
         .build_async(res);
 
     d.dispatch();
@@ -163,8 +163,8 @@ fn dispatch_async_res() {
     res.add(Res);
 
     let mut d = DispatcherBuilder::new()
-        .add(DummySysMut, "a", &[])
-        .add(DummySys, "b", &[])
+        .with(DummySysMut, "a", &[])
+        .with(DummySys, "b", &[])
         .build_async(res);
 
     d.dispatch();
@@ -208,9 +208,9 @@ fn dispatch_stage_group() {
     }
 
     let mut d: Dispatcher = DispatcherBuilder::new()
-        .add(DummySys, "read_a", &[])
-        .add(ReadingFromResB, "read_b", &[])
-        .add(WritingToResB, "write_b", &[])
+        .with(DummySys, "read_a", &[])
+        .with(ReadingFromResB, "read_b", &[])
+        .with(WritingToResB, "write_b", &[])
         .build();
 
     d.dispatch(&mut res);


### PR DESCRIPTION
This pull request changes the `DispatcherBuilder` API to have non-consuming `add_` methods in addition to the consuming `with_` methods. The old `add_` prefix was replaced by a `with_` prefix.

One open question is whether we want the `add_` methods to return `&mut Self` instead of `()`.

Need for this change arose from amethyst/amethyst#304. When standardizing the builder naming in Amethyst, we need non-consuming methods in order to pass Rusts borrow checker.

This is a breaking change.