### PR TITLE
Update readme example to new builder naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ impl<'a> System<'a> for PrintSystem {
 fn main() {
     let mut resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
-        .add(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
+        .with(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();
     resources.add(ResA);
     resources.add(ResB);


### PR DESCRIPTION
I forgot to update the example in the README file in #59.