### PR TITLE
Fix building on emscripten

### DIFF
--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2,12 +2,14 @@
 pub use self::async::AsyncDispatcher;
 pub use self::builder::DispatcherBuilder;
 pub use self::dispatcher::Dispatcher;
+#[cfg(not(target_os = "emscripten"))]
 pub use self::par_seq::{Par, ParSeq, Seq};
 
 #[cfg(not(target_os = "emscripten"))]
 mod async;
 mod builder;
 mod dispatcher;
+#[cfg(not(target_os = "emscripten"))]
 mod par_seq;
 mod stage;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,9 @@ mod dispatch;
 mod res;
 mod system;
 
-pub use dispatch::{Dispatcher, DispatcherBuilder, Par, ParSeq, Seq};
+pub use dispatch::{Dispatcher, DispatcherBuilder};
+#[cfg(not(target_os = "emscripten"))]
+pub use dispatch::{Par, ParSeq, Seq};
 #[cfg(not(target_os = "emscripten"))]
 pub use dispatch::AsyncDispatcher;
 pub use res::{Fetch, FetchId, FetchIdMut, FetchMut, Resource, ResourceId, Resources};


### PR DESCRIPTION
Noticed the build fail when I was trying specs on emscripten. Added missing cfg's to the parts requiring rayon like that was already done