### PR TITLE
Made rayon reference work on emscripten.

### DIFF
--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -1,3 +1,5 @@
+extern crate rayon;
+
 use std::borrow::Borrow;
 
 use dispatch::util::check_intersection;
@@ -5,7 +7,7 @@ use res::{ResourceId, Resources};
 use system::RunNow;
 use system::System;
 
-use rayon::{join, ThreadPool};
+use self::rayon::{join, ThreadPool};
 
 /// The "leave node" for the `Par` / `Seq` list.
 pub struct Nil;


### PR DESCRIPTION
I don't specifically know why this is needed, but when building under Emscripten via cargo-web, rayon cannot be found without this change. Works fine via regular builds, so I'm not sure what's different in the emscripten build environment.

These changes fix my problem without breaking regular builds. Would be nice to merge and release a new version so I can get specs working in my wasm project. I can't seem to get this working by overriding the dependency in my own Cargo.toml.

Thanks!