### PR TITLE
Backport emscripten fix to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["torkleyy <torkleyy@gmail.com>"]
 description = """
 Dispatches systems in parallel which need read access to some resources,

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2,12 +2,14 @@
 pub use self::async::AsyncDispatcher;
 pub use self::builder::DispatcherBuilder;
 pub use self::dispatcher::Dispatcher;
+#[cfg(not(target_os = "emscripten"))]
 pub use self::par_seq::{Par, ParSeq, Seq};
 
 #[cfg(not(target_os = "emscripten"))]
 mod async;
 mod builder;
 mod dispatcher;
+#[cfg(not(target_os = "emscripten"))]
 mod par_seq;
 mod stage;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,9 @@ mod dispatch;
 mod res;
 mod system;
 
-pub use dispatch::{Dispatcher, DispatcherBuilder, Par, ParSeq, Seq};
+pub use dispatch::{Dispatcher, DispatcherBuilder};
+#[cfg(not(target_os = "emscripten"))]
+pub use dispatch::{Par, ParSeq, Seq};
 #[cfg(not(target_os = "emscripten"))]
 pub use dispatch::AsyncDispatcher;
 pub use res::{Fetch, FetchId, FetchIdMut, FetchMut, Resource, ResourceId, Resources};


### PR DESCRIPTION
Closes #62 

I realized that this fix was not included in the latest version of `shred`. Please tell me if it works for you using `shred` 0.5.1 (I'll release once this PR is merged).