### PR TITLE
Add `print_par_seq`

### DIFF
--- a/examples/par_seq.rs
+++ b/examples/par_seq.rs
@@ -61,4 +61,50 @@ fn main() {
     );
 
     dispatcher.dispatch(&res);
+
+    // If we want to generate this graph from a `DispatcherBuilder`,
+    // we can use `print_par_seq`:
+
+    use shred::DispatcherBuilder;
+
+    DispatcherBuilder::new()
+        .with(SysA, "sys_a", &[])
+        .with(SysWithLifetime(&x), "sys_lt", &[])
+        .with(SysC, "sys_c", &[])
+        .with(SysD, "sys_d", &["sys_c"])
+        .with(SysB, "sys_b", &["sys_a", "sys_lt", "sys_c", "sys_d"])
+        // doesn't work with `Dispatcher`
+        // .with(SysLocal(&x as *const u8), "sys_local", &["sys_b"])
+        .print_par_seq();
+
+    // This prints:
+
+    /*
+seq![
+    par![
+        seq![
+            sys_a,
+        ],
+        seq![
+            sys_lt,
+        ],
+        seq![
+            sys_c,
+        ],
+    ],
+    par![
+        seq![
+            sys_d,
+        ],
+    ],
+    par![
+        seq![
+            sys_b,
+        ],
+    ],
+]
+    */
+
+    // This can now be pasted into a source file.
+    // After replacing the system names with the actual systems, you can optimize it.
 }

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use fxhash::FxHashMap;
 
 use dispatch::Dispatcher;
@@ -257,7 +259,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     /// that can be easily used to get the graph using the `seq!` and `par!`
     /// macros. This is only recommended for advanced users.
     pub fn print_par_seq(&self) {
-        self.stages_builder.print_par_seq(&self.map);
+        println!("{:#?}", self);
     }
 
     /// Builds the `Dispatcher`.
@@ -314,5 +316,11 @@ impl<'b> DispatcherBuilder<'static, 'b> {
             self.thread_local,
             self.thread_pool.unwrap_or_else(Self::create_thread_pool),
         )
+    }
+}
+
+impl<'a, 'b> fmt::Debug for DispatcherBuilder<'a, 'b> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.stages_builder.write_par_seq(f, &self.map)
     }
 }

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -253,6 +253,13 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
         self.thread_pool = Some(pool);
     }
 
+    /// Prints the equivalent system graph
+    /// that can be easily used to get the graph using the `seq!` and `par!`
+    /// macros. This is only recommended for advanced users.
+    pub fn print_par_seq(&self) {
+        self.stages_builder.print_par_seq(&self.map);
+    }
+
     /// Builds the `Dispatcher`.
     ///
     /// In the future, this method will

--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -33,7 +33,7 @@ pub struct Nil;
 /// ```
 #[macro_export]
 macro_rules! par {
-    ($head:expr, $( $tail:expr ,)+) => {
+    ($head:expr, $( $tail:expr ,)*) => {
         {
             $crate::Par::new($head)
                 $( .with($tail) )*
@@ -63,7 +63,7 @@ macro_rules! par {
 /// ```
 #[macro_export]
 macro_rules! seq {
-    ($head:expr, $( $tail:expr ,)+) => {
+    ($head:expr, $( $tail:expr ,)*) => {
         {
             $crate::Seq::new($head)
                 $( .with($tail) )*

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -31,6 +31,7 @@
 //!
 
 use arrayvec::ArrayVec;
+use fxhash::FxHashMap;
 use smallvec::SmallVec;
 
 use dispatch::dispatcher::{SystemExecSend, SystemId};
@@ -154,6 +155,32 @@ impl<'a> StagesBuilder<'a> {
 
     pub fn build(self) -> Vec<Stage<'a>> {
         self.stages
+    }
+
+    pub fn print_par_seq(&self, map: &FxHashMap<String, SystemId>) {
+        println!("seq![");
+        for stage in &self.ids {
+            println!("\tpar![");
+            for group in stage {
+                println!("\t\tseq![");
+                for system in group {
+                    let system: &SystemId = system;
+
+                    let mut name = map
+                        .iter()
+                        .find(|&(_, id)| *id == *system)
+                        .map(|(name, _)| name)
+                        .unwrap()
+                        .to_string();
+                    name.replace(|c| c == ' ' || c == '-' || c == '/', "_");
+
+                    println!("\t\t\t{},", name);
+                }
+                println!("\t\t],");
+            }
+            println!("\t],");
+        }
+        println!("]");
     }
 
     fn add_stage(&mut self) {

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -30,6 +30,8 @@
 //!   in code).
 //!
 
+use std::fmt;
+
 use arrayvec::ArrayVec;
 use fxhash::FxHashMap;
 use smallvec::SmallVec;
@@ -157,30 +159,27 @@ impl<'a> StagesBuilder<'a> {
         self.stages
     }
 
-    pub fn print_par_seq(&self, map: &FxHashMap<String, SystemId>) {
-        println!("seq![");
+    pub fn write_par_seq(&self, f: &mut fmt::Formatter, map: &FxHashMap<String, SystemId>) -> fmt::Result {
+        let map: FxHashMap<_, _> = map.iter().map(|(key, value)| (*value, key as &str)).collect();
+
+        writeln!(f, "seq![")?;
         for stage in &self.ids {
-            println!("\tpar![");
+            writeln!(f, "\tpar![")?;
             for group in stage {
-                println!("\t\tseq![");
+                writeln!(f, "\t\tseq![")?;
                 for system in group {
                     let system: &SystemId = system;
 
-                    let mut name = map
-                        .iter()
-                        .find(|&(_, id)| *id == *system)
-                        .map(|(name, _)| name)
-                        .unwrap()
-                        .to_string();
+                    let mut name = map.get(system).unwrap().to_string();
                     name.replace(|c| c == ' ' || c == '-' || c == '/', "_");
 
-                    println!("\t\t\t{},", name);
+                    writeln!(f, "\t\t\t{},", name)?;
                 }
-                println!("\t\t],");
+                writeln!(f, "\t\t],")?;
             }
-            println!("\t],");
+            writeln!(f, "\t],")?;
         }
-        println!("]");
+        writeln!(f, "]")
     }
 
     fn add_stage(&mut self) {


### PR DESCRIPTION
This allows to quickly get a `ParSeq` structure without double and triple checking dependencies.