### PR TITLE
Disable multithreading for all wasm32 targets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,18 @@ travis-ci = { repository = "torkleyy/shred" }
 arrayvec = "0.3"
 fxhash = "0.2"
 mopa = "0.2"
-pulse = "0.5"
-rayon = "0.8"
+pulse = { version = "0.5", optional = true }
+rayon = { version = "0.8", optional = true }
 shred-derive = { path = "shred-derive", version = "0.3" }
 smallvec = "0.4"
 
 [dev-dependencies]
 cgmath = "0.15"
+
+[features]
+default = ["parallel"]
+parallel = ["pulse", "rayon"]
+
+[[example]]
+name = "par_seq"
+required-features = ["parallel"]

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -1,15 +1,15 @@
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 pub use self::async::AsyncDispatcher;
 pub use self::builder::DispatcherBuilder;
 pub use self::dispatcher::Dispatcher;
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 pub use self::par_seq::{Par, ParSeq, Seq};
 
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 mod async;
 mod builder;
 mod dispatcher;
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 mod par_seq;
 mod stage;
 mod util;

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -76,7 +76,7 @@ impl<'a> Stage<'a> {
         Default::default()
     }
 
-    #[cfg(not(target_os = "emscripten"))]
+    #[cfg(feature = "parallel")]
     pub fn execute(&mut self, res: &Resources) {
         use rayon::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,9 @@ extern crate arrayvec;
 extern crate fxhash;
 #[macro_use]
 extern crate mopa;
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 extern crate pulse;
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 extern crate rayon;
 extern crate smallvec;
 
@@ -73,9 +73,9 @@ mod res;
 mod system;
 
 pub use dispatch::{Dispatcher, DispatcherBuilder};
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 pub use dispatch::{Par, ParSeq, Seq};
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(feature = "parallel")]
 pub use dispatch::AsyncDispatcher;
 pub use res::{Fetch, FetchId, FetchIdMut, FetchMut, Resource, ResourceId, Resources};
 pub use system::{RunNow, RunningTime, System, SystemData};


### PR DESCRIPTION
With the coming of `wasm32-unknown-unknown` it might be good idea to use `target_arch = "wasm32"` to detect whether to build with multithreading support or not.