### PR TITLE
Remove resource ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ arrayvec = "0.4"
 fxhash = "0.2"
 mopa = "0.2"
 rayon = { version = "0.9", optional = true }
-shred-derive = { path = "shred-derive", version = "0.3" }
+shred-derive = { path = "shred-derive", version = "0.4" }
 smallvec = "0.6"
 
 [dev-dependencies]

--- a/examples/custom_bundle.rs
+++ b/examples/custom_bundle.rs
@@ -14,19 +14,19 @@ struct ExampleBundle<'a> {
 }
 
 impl<'a> SystemData<'a> for ExampleBundle<'a> {
-    fn fetch(res: &'a Resources, id: usize) -> Self {
+    fn fetch(res: &'a Resources) -> Self {
         ExampleBundle {
-            a: res.fetch(id),
-            b: res.fetch_mut(id),
+            a: res.fetch(),
+            b: res.fetch_mut(),
         }
     }
 
-    fn reads(id: usize) -> Vec<ResourceId> {
-        vec![ResourceId::new_with_id::<ResA>(id)]
+    fn reads() -> Vec<ResourceId> {
+        vec![ResourceId::new::<ResA>()]
     }
 
-    fn writes(id: usize) -> Vec<ResourceId> {
-        vec![ResourceId::new_with_id::<ResB>(id)]
+    fn writes() -> Vec<ResourceId> {
+        vec![ResourceId::new::<ResB>()]
     }
 }
 
@@ -36,7 +36,7 @@ fn main() {
     res.add(ResB);
 
 
-    let mut bundle = ExampleBundle::fetch(&res, 0);
+    let mut bundle = ExampleBundle::fetch(&res);
     *bundle.b = ResB;
 
     println!("{:?}", *bundle.a);

--- a/examples/derive_bundle.rs
+++ b/examples/derive_bundle.rs
@@ -29,7 +29,7 @@ fn main() {
 
 
     {
-        let mut bundle = AutoBundle::fetch(&res, 0);
+        let mut bundle = AutoBundle::fetch(&res);
 
         *bundle.b = ResB;
 
@@ -38,7 +38,7 @@ fn main() {
     }
 
     {
-        let nested = Nested::fetch(&res, 0);
+        let nested = Nested::fetch(&res);
 
         println!("a: {:?}", *nested.inner.a);
     }

--- a/shred-derive/Cargo.toml
+++ b/shred-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred-derive"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["torkleyy"]
 description = "Custom derive for shred"
 documentation = "https://docs.rs/shred_derive"

--- a/shred-derive/src/lib.rs
+++ b/shred-derive/src/lib.rs
@@ -10,8 +10,7 @@ use quote::Tokens;
 use syn::{Body, Field, Ident, Lifetime, LifetimeDef, MacroInput, Ty, TyParam, VariantData,
           WhereClause};
 
-/// Used to `#[derive]` the trait
-/// `SystemData`.
+/// Used to `#[derive]` the trait `SystemData`.
 #[proc_macro_derive(SystemData)]
 pub fn system_data(input: TokenStream) -> TokenStream {
     let s = input.to_string();
@@ -50,26 +49,26 @@ fn impl_system_data(ast: &MacroInput) -> Tokens {
             for #name< #impl_lt_tokens , #impl_ty_params >
             where #where_clause
         {
-            fn fetch(res: & #impl_fetch_lt ::shred::Resources, id: usize) -> Self {
+            fn fetch(res: & #impl_fetch_lt ::shred::Resources) -> Self {
                 #fetch_return
             }
 
-            fn reads(id: usize) -> Vec<::shred::ResourceId> {
+            fn reads() -> Vec<::shred::ResourceId> {
                 let mut r = Vec::new();
 
                 #( {
-                        let mut reads = <#tys as ::shred::SystemData> :: reads(id);
+                        let mut reads = <#tys as ::shred::SystemData> :: reads();
                         r.append(&mut reads);
                     } )*
 
                 r
             }
 
-            fn writes(id: usize) -> Vec<::shred::ResourceId> {
+            fn writes() -> Vec<::shred::ResourceId> {
                 let mut r = Vec::new();
 
                 #( {
-                        let mut writes = <#tys as ::shred::SystemData> :: writes(id);
+                        let mut writes = <#tys as ::shred::SystemData> :: writes();
                         r.append(&mut writes);
                     } )*
 
@@ -163,13 +162,13 @@ fn gen_from_body(ast: &Body, name: &Ident) -> (Tokens, Vec<Ty>) {
 
             quote! {
                 #name {
-                    #( #identifiers: ::shred::SystemData::fetch(res, id) ),*
+                    #( #identifiers: ::shred::SystemData::fetch(res) ),*
                 }
             }
         }
         BodyType::Tuple => {
             let count = tys.len();
-            let fetch = vec![quote! { ::shred::SystemData::fetch(res, id) }; count];
+            let fetch = vec![quote! { ::shred::SystemData::fetch(res) }; count];
 
             quote! {
                 #name ( #( #fetch ),* )

--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -254,13 +254,13 @@ where
     fn reads(&self, reads: &mut Vec<ResourceId>) {
         use system::SystemData;
 
-        reads.extend(T::SystemData::reads(0))
+        reads.extend(T::SystemData::reads())
     }
 
     fn writes(&self, writes: &mut Vec<ResourceId>) {
         use system::SystemData;
 
-        writes.extend(T::SystemData::writes(0))
+        writes.extend(T::SystemData::writes())
     }
 }
 

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -120,8 +120,8 @@ impl<'a> StagesBuilder<'a> {
     {
         use system::SystemData;
 
-        let mut reads = T::SystemData::reads(0);
-        let writes = T::SystemData::writes(0);
+        let mut reads = T::SystemData::reads();
+        let writes = T::SystemData::writes();
 
         reads.sort();
         reads.dedup();

--- a/src/system.rs
+++ b/src/system.rs
@@ -20,7 +20,7 @@ where
     T: System<'a>,
 {
     fn run_now(&mut self, res: &'a Resources) {
-        let data = T::SystemData::fetch(res, 0);
+        let data = T::SystemData::fetch(res);
         self.run(data);
     }
 }
@@ -77,7 +77,7 @@ pub trait SystemData<'a> {
     /// returned from `reads` / `writes`!
     ///
     /// [`Resources`]: trait.Resources.html
-    fn fetch(res: &'a Resources, id: usize) -> Self;
+    fn fetch(res: &'a Resources) -> Self;
 
     /// A list of [`ResourceId`]s the bundle
     /// needs read access to in order to
@@ -94,7 +94,7 @@ pub trait SystemData<'a> {
     /// (otherwise it has no effect).
     ///
     /// [`ResourceId`]: struct.ResourceId.html
-    fn reads(id: usize) -> Vec<ResourceId>;
+    fn reads() -> Vec<ResourceId>;
 
     /// A list of [`ResourceId`]s the bundle
     /// needs write access to in order to
@@ -111,19 +111,19 @@ pub trait SystemData<'a> {
     /// (otherwise it has no effect).
     ///
     /// [`ResourceId`]: struct.ResourceId.html
-    fn writes(id: usize) -> Vec<ResourceId>;
+    fn writes() -> Vec<ResourceId>;
 }
 
 impl<'a, T: ?Sized> SystemData<'a> for PhantomData<T> {
-    fn fetch(_: &'a Resources, _: usize) -> Self {
+    fn fetch(_: &'a Resources) -> Self {
         PhantomData
     }
 
-    fn reads(_: usize) -> Vec<ResourceId> {
+    fn reads() -> Vec<ResourceId> {
         Vec::new()
     }
 
-    fn writes(_: usize) -> Vec<ResourceId> {
+    fn writes() -> Vec<ResourceId> {
         Vec::new()
     }
 }
@@ -133,32 +133,32 @@ macro_rules! impl_data {
         impl<'a, $($ty),*> SystemData<'a> for ( $( $ty , )* )
             where $( $ty : SystemData<'a> ),*
         {
-            fn fetch(res: &'a Resources, id: usize) -> Self {
+            fn fetch(res: &'a Resources) -> Self {
                 #![allow(unused_variables)]
 
-                ( $( <$ty as SystemData<'a>>::fetch(res, id.clone()), )* )
+                ( $( <$ty as SystemData<'a>>::fetch(res), )* )
             }
 
-            fn reads(id: usize) -> Vec<ResourceId> {
+            fn reads() -> Vec<ResourceId> {
                 #![allow(unused_mut)]
 
                 let mut r = Vec::new();
 
                 $( {
-                        let mut reads = <$ty as SystemData>::reads(id.clone());
+                        let mut reads = <$ty as SystemData>::reads();
                         r.append(&mut reads);
                     } )*
 
                 r
             }
 
-            fn writes(id: usize) -> Vec<ResourceId> {
+            fn writes() -> Vec<ResourceId> {
                 #![allow(unused_mut)]
 
                 let mut r = Vec::new();
 
                 $( {
-                        let mut writes = <$ty as SystemData>::writes(id.clone());
+                        let mut writes = <$ty as SystemData>::writes();
                         r.append(&mut writes);
                     } )*
 
@@ -169,15 +169,15 @@ macro_rules! impl_data {
 }
 
 impl<'a> SystemData<'a> for () {
-    fn fetch(_: &'a Resources, _: usize) -> Self {
+    fn fetch(_: &'a Resources) -> Self {
         ()
     }
 
-    fn reads(_: usize) -> Vec<ResourceId> {
+    fn reads() -> Vec<ResourceId> {
         Vec::new()
     }
 
-    fn writes(_: usize) -> Vec<ResourceId> {
+    fn writes() -> Vec<ResourceId> {
         Vec::new()
     }
 }

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -170,7 +170,7 @@ fn dispatch_async_res() {
     d.dispatch();
 
     let res = d.mut_res();
-    res.add_with_id(Res, 2);
+    res.add(ResB);
 }
 
 #[test]


### PR DESCRIPTION
Motivation for this change: Fetching with an id other than `0` is only possible outside a system or with a custom struct (which can only fetch a constant id). The plan was to use this for scripting, but resources added by scripts can easily be maintained by another resource, since access of those "script resources" is special anyways. This PR removes the unnecessary complexity and improves `Resources` access.

Resource ids were also a source of confusion in Specs where people thought that resource ids / component ids have something to do with entities.