### PR TITLE
Systems without lifetimes

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -78,17 +78,17 @@ const NUM_COMPONENTS: usize = 200;
 // --------------
 
 #[derive(SystemData)]
-struct SpringForceData<'a> {
-    pos: Read<'a, PosStorage>,
-    spring: Read<'a, SpringStorage>,
+struct SpringForceData {
+    pos: Read<PosStorage>,
+    spring: Read<SpringStorage>,
 
-    force: Write<'a, ForceStorage>,
+    force: Write<ForceStorage>,
 }
 
 struct SpringForce;
 
-impl<'a> System<'a> for SpringForce {
-    type SystemData = SpringForceData<'a>;
+impl System for SpringForce {
+    type SystemData = SpringForceData;
 
     fn run(&mut self, mut data: SpringForceData) {
         for elem in 0..NUM_COMPONENTS {
@@ -110,19 +110,19 @@ impl<'a> System<'a> for SpringForce {
 }
 
 #[derive(SystemData)]
-struct IntegrationData<'a> {
-    force: Read<'a, ForceStorage>,
-    mass: Read<'a, MassStorage>,
-    pos: Write<'a, PosStorage>,
-    vel: Write<'a, VelStorage>,
+struct IntegrationData {
+    force: Read<ForceStorage>,
+    mass: Read<MassStorage>,
+    pos: Write<PosStorage>,
+    vel: Write<VelStorage>,
 
-    time: Option<Read<'a, DeltaTime>>,
+    time: Option<Read<DeltaTime>>,
 }
 
 struct IntegrationSystem;
 
-impl<'a> System<'a> for IntegrationSystem {
-    type SystemData = IntegrationData<'a>;
+impl System for IntegrationSystem {
+    type SystemData = IntegrationData;
 
     fn run(&mut self, mut data: IntegrationData) {
         let delta = match data.time {
@@ -155,14 +155,14 @@ impl<'a> System<'a> for IntegrationSystem {
 }
 
 #[derive(SystemData)]
-struct ClearForceAccumData<'a> {
-    force: Write<'a, ForceStorage>,
+struct ClearForceAccumData {
+    force: Write<ForceStorage>,
 }
 
 struct ClearForceAccum;
 
-impl<'a> System<'a> for ClearForceAccum {
-    type SystemData = ClearForceAccumData<'a>;
+impl System for ClearForceAccum {
+    type SystemData = ClearForceAccumData;
 
     fn run(&mut self, mut data: ClearForceAccumData) {
         for elem in 0..NUM_COMPONENTS {

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -11,17 +11,17 @@ struct ResA;
 struct ResB;
 
 #[derive(SystemData)]
-struct Data<'a> {
-    a: Read<'a, ResA>,
-    b: Write<'a, ResB>,
+struct Data {
+    a: Read<ResA>,
+    b: Write<ResB>,
 }
 
 struct EmptySystem(*mut i8); // System is not thread-safe
 
-impl<'a> System<'a> for EmptySystem {
-    type SystemData = Data<'a>;
+impl System for EmptySystem {
+    type SystemData = Data;
 
-    fn run(&mut self, bundle: Data<'a>) {
+    fn run(&mut self, bundle: Data) {
         println!("thread local: {:?}", &*bundle.a);
         println!("thread local: {:?}", &*bundle.b);
     }
@@ -29,8 +29,8 @@ impl<'a> System<'a> for EmptySystem {
 
 struct PrintSystem;
 
-impl<'a> System<'a> for PrintSystem {
-    type SystemData = (Read<'a, ResA>, Write<'a, ResB>);
+impl System for PrintSystem {
+    type SystemData = (Read<ResA>, Write<ResB>);
 
     fn run(&mut self, data: Self::SystemData) {
         let (a, mut b) = data;

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -12,8 +12,8 @@ struct ResB;
 
 struct PrintSystem;
 
-impl<'a> System<'a> for PrintSystem {
-    type SystemData = (Read<'a, ResA>, Write<'a, ResB>);
+impl System for PrintSystem {
+    type SystemData = (Read<ResA>, Write<ResB>);
 
     fn run(&mut self, data: Self::SystemData) {
         let (a, mut b) = data;

--- a/examples/derive_bundle.rs
+++ b/examples/derive_bundle.rs
@@ -11,15 +11,15 @@ struct ResA;
 struct ResB;
 
 #[derive(SystemData)]
-struct AutoBundle<'a> {
-    a: Read<'a, ResA>,
-    b: Write<'a, ResB>,
+struct AutoBundle {
+    a: Read<ResA>,
+    b: Write<ResB>,
 }
 
 // We can even nest system data
 #[derive(SystemData)]
-struct Nested<'a> {
-    inner: AutoBundle<'a>,
+struct Nested {
+    inner: AutoBundle,
 }
 
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
     res.insert(ResB);
 
     {
-        let mut bundle = AutoBundle::fetch(&res);
+        let mut bundle = AutoBundle::fetch(&res).into_inner();
 
         *bundle.b = ResB;
 
@@ -37,7 +37,7 @@ fn main() {
     }
 
     {
-        let nested = Nested::fetch(&res);
+        let nested = Nested::fetch(&res).into_inner();
 
         println!("a: {:?}", *nested.inner.a);
     }

--- a/examples/fetch_opt.rs
+++ b/examples/fetch_opt.rs
@@ -15,15 +15,15 @@ struct ResWithoutSensibleDefault {
 
 struct PrintSystem;
 
-impl<'a> System<'a> for PrintSystem {
+impl System for PrintSystem {
     // We can simply use `Option<Read>` or `Option<Write>` if a resource
     // isn't strictly required or can't be created (by a `Default` implementation).
     type SystemData = (
-        Read<'a, ResA>,
-        Option<Write<'a, ResB>>,
+        Read<ResA>,
+        Option<Write<ResB>>,
         // WARNING: using `ReadExpect` might lead to a panic!
         // If `ResWithoutSensibleDefault` does not exist, fetching will `panic!`.
-        ReadExpect<'a, ResWithoutSensibleDefault>,
+        ReadExpect<ResWithoutSensibleDefault>,
     );
 
     fn run(&mut self, data: Self::SystemData) {

--- a/examples/generic_derive.rs
+++ b/examples/generic_derive.rs
@@ -11,19 +11,19 @@ use shred::{Read, Resource, Write};
 trait Hrtb<'a> {}
 
 #[derive(SystemData)]
-struct VeryCustomDerive<'a, T: Debug + Resource + for<'b> Hrtb<'b>> {
-    _b: Write<'a, T>,
+struct VeryCustomDerive<T: Debug + Resource + for<'b> Hrtb<'b>> {
+    _b: Write<T>,
 }
 
 #[derive(SystemData)]
-struct SomeTuple<'a, T: Debug + Resource>(Read<'a, T>);
+struct SomeTuple<T: Debug + Resource>(Read<T>);
 
 #[derive(SystemData)]
-struct WithWhereClause<'a, T>
+struct WithWhereClause<T>
 where
     T: Resource,
 {
-    k: Read<'a, T>,
+    k: Read<T>,
 }
 
 fn main() {}

--- a/examples/par_seq.rs
+++ b/examples/par_seq.rs
@@ -9,7 +9,7 @@ use shred::{ParSeq, Read, Resources, System};
 macro_rules! impl_sys {
     ($( $id:ident )*) => {
         $(
-            impl<'a> ::shred::System<'a> for $id {
+            impl ::shred::System for $id {
                 type SystemData = ();
                 fn run(&mut self, _: Self::SystemData) {
                     println!(stringify!($id));
@@ -28,10 +28,10 @@ struct SysLocal(*const u8);
 
 impl_sys!(SysA SysB SysC SysD SysLocal);
 
-impl<'a, 'b> System<'a> for SysWithLifetime<'b> {
-    type SystemData = Read<'a, u64>;
+impl<'b> System for SysWithLifetime<'b> {
+    type SystemData = Read<u64>;
 
-    fn run(&mut self, nr: Read<'a, u64>) {
+    fn run(&mut self, nr: Read<u64>) {
         println!("SysWithLifetime, {}", *nr);
     }
 }

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -11,17 +11,17 @@ struct ResA;
 struct ResB;
 
 #[derive(SystemData)]
-struct Data<'a> {
-    a: Read<'a, ResA>,
-    b: Write<'a, ResB>,
+struct Data {
+    a: Read<ResA>,
+    b: Write<ResB>,
 }
 
 struct EmptySystem;
 
-impl<'a> System<'a> for EmptySystem {
-    type SystemData = Data<'a>;
+impl System for EmptySystem {
+    type SystemData = Data;
 
-    fn run(&mut self, bundle: Data<'a>) {
+    fn run(&mut self, bundle: Data) {
         println!("{:?}", &*bundle.a);
         println!("{:?}", &*bundle.b);
     }

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -11,17 +11,17 @@ struct ResA;
 struct ResB;
 
 #[derive(SystemData)]
-struct Data<'a> {
-    a: Read<'a, ResA>,
-    b: Write<'a, ResB>,
+struct Data {
+    a: Read<ResA>,
+    b: Write<ResB>,
 }
 
 struct EmptySystem(*mut i8); // System is not thread-safe
 
-impl<'a> System<'a> for EmptySystem {
-    type SystemData = Data<'a>;
+impl System for EmptySystem {
+    type SystemData = Data;
 
-    fn run(&mut self, bundle: Data<'a>) {
+    fn run(&mut self, bundle: Data) {
         println!("{:?}", &*bundle.a);
         println!("{:?}", &*bundle.b);
     }

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -29,12 +29,12 @@ use system::{RunNow, System};
 /// # extern crate shred_derive;
 /// # use shred::{Dispatcher, DispatcherBuilder, Read, System};
 /// # #[derive(Debug, Default)] struct Res;
-/// # #[derive(SystemData)] #[allow(unused)] struct Data<'a> { a: Read<'a, Res> }
+/// # #[derive(SystemData)] #[allow(unused)] struct Data { a: Read<Res> }
 /// # struct Dummy;
-/// # impl<'a> System<'a> for Dummy {
-/// #   type SystemData = Data<'a>;
+/// # impl System for Dummy {
+/// #   type SystemData = Data;
 /// #
-/// #   fn run(&mut self, _: Data<'a>) {}
+/// #   fn run(&mut self, _: Data) {}
 /// # }
 /// #
 /// # fn main() {
@@ -63,12 +63,12 @@ use system::{RunNow, System};
 /// # extern crate shred_derive;
 /// # use shred::{Dispatcher, DispatcherBuilder, Read, System};
 /// # #[derive(Debug, Default)] struct Res;
-/// # #[derive(SystemData)] #[allow(unused)] struct Data<'a> { a: Read<'a, Res> }
+/// # #[derive(SystemData)] #[allow(unused)] struct Data { a: Read<Res> }
 /// # struct Dummy;
-/// # impl<'a> System<'a> for Dummy {
-/// #   type SystemData = Data<'a>;
+/// # impl System for Dummy {
+/// #   type SystemData = Data;
 /// #
-/// #   fn run(&mut self, _: Data<'a>) {}
+/// #   fn run(&mut self, _: Data) {}
 /// # }
 /// #
 /// # fn main() {
@@ -123,7 +123,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     /// * if a system with the same name was already registered.
     pub fn with<T>(mut self, system: T, name: &str, dep: &[&str]) -> Self
     where
-        T: for<'c> System<'c> + Send + 'a,
+        T: System + Send + 'a,
     {
         self.add(system, name, dep);
 
@@ -144,7 +144,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     /// * if a system with the same name was already registered.
     pub fn add<T>(&mut self, system: T, name: &str, dep: &[&str])
     where
-        T: for<'c> System<'c> + Send + 'a,
+        T: System + Send + 'a,
     {
         use std::collections::hash_map::Entry;
 
@@ -183,7 +183,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     /// but returns `self` to enable method chaining.
     pub fn with_thread_local<T>(mut self, system: T) -> Self
     where
-        T: for<'c> RunNow<'c> + 'b,
+        T: RunNow + 'b,
     {
         self.add_thread_local(system);
 
@@ -197,7 +197,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     /// Thread-local systems are dispatched in-order.
     pub fn add_thread_local<T>(&mut self, system: T)
     where
-        T: for<'c> RunNow<'c> + 'b,
+        T: RunNow + 'b,
     {
         self.thread_local.push(Box::new(system));
     }

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -107,7 +107,7 @@ impl<'a, 'b> Dispatcher<'a, 'b> {
     }
 }
 
-impl<'a, 'b, 'c> RunNow<'a> for Dispatcher<'b, 'c> {
+impl<'b, 'c> RunNow for Dispatcher<'b, 'c> {
     fn run_now(&mut self, res: &Resources) {
         self.dispatch(res);
     }
@@ -120,8 +120,8 @@ impl<'a, 'b, 'c> RunNow<'a> for Dispatcher<'b, 'c> {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct SystemId(pub usize);
 
-pub type SystemExecSend<'b> = Box<for<'a> RunNow<'a> + Send + 'b>;
-pub type ThreadLocal<'a> = SmallVec<[Box<for<'b> RunNow<'b> + 'a>; 4]>;
+pub type SystemExecSend<'b> = Box<RunNow + Send + 'b>;
+pub type ThreadLocal<'a> = SmallVec<[Box<RunNow + 'a>; 4]>;
 
 #[cfg(feature = "parallel")]
 pub fn new_dispatcher<'a, 'b>(
@@ -158,8 +158,8 @@ mod tests {
 
     struct Dummy(i32);
 
-    impl<'a> System<'a> for Dummy {
-        type SystemData = Write<'a, Res>;
+    impl System for Dummy {
+        type SystemData = Write<Res>;
 
         fn run(&mut self, mut data: Self::SystemData) {
             if self.0 == 4 {
@@ -178,7 +178,7 @@ mod tests {
 
     struct Panic;
 
-    impl<'a> System<'a> for Panic {
+    impl System for Panic {
         type SystemData = ();
 
         fn run(&mut self, _: Self::SystemData) {

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -131,7 +131,7 @@ impl<'a> StagesBuilder<'a> {
 
     pub fn insert<T>(&mut self, mut dep: SmallVec<[SystemId; 4]>, id: SystemId, system: T)
     where
-        T: for<'b> System<'b> + Send + 'a,
+        T: System + Send + 'a,
     {
         use system::Accessor;
 
@@ -468,16 +468,16 @@ mod tests {
 
         struct SysA;
 
-        impl<'a> System<'a> for SysA {
-            type SystemData = Read<'a, ResA>;
+        impl System for SysA {
+            type SystemData = Read<ResA>;
 
             fn run(&mut self, _: Self::SystemData) {}
         }
 
         struct SysB;
 
-        impl<'a> System<'a> for SysB {
-            type SystemData = Write<'a, ResB>;
+        impl System for SysB {
+            type SystemData = Write<ResB>;
 
             fn run(&mut self, _: Self::SystemData) {}
 
@@ -488,8 +488,8 @@ mod tests {
 
         struct SysC;
 
-        impl<'a> System<'a> for SysC {
-            type SystemData = Read<'a, ResB>;
+        impl System for SysC {
+            type SystemData = Read<ResB>;
 
             fn run(&mut self, _: Self::SystemData) {}
 
@@ -521,7 +521,7 @@ mod tests {
 
         struct Sys;
 
-        impl<'a> System<'a> for Sys {
+        impl System for Sys {
             type SystemData = ();
 
             fn run(&mut self, _: Self::SystemData) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,17 +20,17 @@
 //! struct ResB;
 //!
 //! #[derive(SystemData)]
-//! struct Data<'a> {
-//!     a: Read<'a, ResA>,
-//!     b: Write<'a, ResB>,
+//! struct Data {
+//!     a: Read<ResA>,
+//!     b: Write<ResB>,
 //! }
 //!
 //! struct EmptySystem;
 //!
-//! impl<'a> System<'a> for EmptySystem {
-//!     type SystemData = Data<'a>;
+//! impl System for EmptySystem {
+//!     type SystemData = Data;
 //!
-//!     fn run(&mut self, bundle: Data<'a>) {
+//!     fn run(&mut self, bundle: Data) {
 //!         println!("{:?}", &*bundle.a);
 //!         println!("{:?}", &*bundle.b);
 //!     }
@@ -82,4 +82,4 @@ pub use meta::{CastFrom, MetaIter, MetaIterMut, MetaTable};
 pub use res::{DefaultProvider, Entry, Fetch, FetchMut, PanicHandler, Read, ReadExpect, Resource,
               ResourceId, Resources, SetupHandler, Write, WriteExpect};
 pub use system::{Accessor, AccessorCow, RunNow, RunningTime, StaticAccessor, SystemData,
-                 System, DynamicSystemData};
+                 System, DynamicSystemData, SystemFetch};

--- a/src/res/entry.rs
+++ b/src/res/entry.rs
@@ -44,12 +44,7 @@ where
     {
         let value = self.inner
             .or_insert_with(move || TrustCell::new(Box::new(f())));
-        let inner = value.borrow_mut();
-
-        FetchMut {
-            inner,
-            phantom: PhantomData,
-        }
+        FetchMut::from(value.borrow_mut())
     }
 }
 

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -17,19 +17,19 @@ struct Res;
 struct ResB;
 
 #[derive(SystemData)]
-struct DummyData<'a> {
-    _res: Read<'a, Res>,
+struct DummyData {
+    _res: Read<Res>,
 }
 
 #[derive(SystemData)]
-struct DummyDataMut<'a> {
-    _res: Write<'a, Res>,
+struct DummyDataMut {
+    _res: Write<Res>,
 }
 
 struct DummySys;
 
-impl<'a> System<'a> for DummySys {
-    type SystemData = DummyData<'a>;
+impl System for DummySys {
+    type SystemData = DummyData;
 
     fn run(&mut self, _data: Self::SystemData) {
         sleep_short()
@@ -38,8 +38,8 @@ impl<'a> System<'a> for DummySys {
 
 struct DummySysMut;
 
-impl<'a> System<'a> for DummySysMut {
-    type SystemData = DummyDataMut<'a>;
+impl System for DummySysMut {
+    type SystemData = DummyDataMut;
 
     fn run(&mut self, _data: Self::SystemData) {
         sleep_short()
@@ -48,7 +48,7 @@ impl<'a> System<'a> for DummySysMut {
 
 struct Whatever<'a>(&'a i32);
 
-impl<'a, 'b> System<'a> for Whatever<'b> {
+impl<'b> System for Whatever<'b> {
     type SystemData = ();
 
     fn run(&mut self, _: Self::SystemData) {
@@ -183,8 +183,8 @@ fn dispatch_stage_group() {
 
     struct ReadingFromResB;
 
-    impl<'a> System<'a> for ReadingFromResB {
-        type SystemData = Read<'a, ResB>;
+    impl System for ReadingFromResB {
+        type SystemData = Read<ResB>;
 
         fn run(&mut self, _: Self::SystemData) {
             sleep_short()
@@ -197,8 +197,8 @@ fn dispatch_stage_group() {
 
     struct WritingToResB;
 
-    impl<'a> System<'a> for WritingToResB {
-        type SystemData = Write<'a, ResB>;
+    impl System for WritingToResB {
+        type SystemData = Write<ResB>;
 
         fn run(&mut self, _: Self::SystemData) {
             sleep_short()


### PR DESCRIPTION
Hey!

So to start out: **this is an experiment**. I don't expect it to be merged, but I also want to make sure to document that I took this approach for a spin.

I was reading the shred code to try to understand what the lifetime associated to systems was actually used for.

The lifetime appears to be required to have [a named lifetime in the `fetch` function](https://github.com/slide-rs/shred/blob/master/src/system.rs#L193) that is _also_ associated with the return value (e.g. `Self`).

This guarantees that `Resources` cannot be modified, while the fetch function is running.

I then tried to figure out what the scope of this lifetime would be. And it appears like this doesn't actually come into effect that much. Primarily it's used in `RunNow`:
https://github.com/slide-rs/shred/blob/master/src/system.rs#L124

But here is the kicker: `resources` is already borrowed here, so do we really need to track the lifetime of the values borrowed from it? These should already be valid for the duration of this function call, which calls into the `System` itself.

So this is a patch that removes that lifetime, in favor of making `Read` and `Write` keep track of a raw pointer into [`TrustCell`](https://github.com/slide-rs/shred/blob/386995e82200e0d6362a4a1c3bccee8d48050d5c/src/cell.rs#L83).

#### Some major caveats
Resources wrapped in`Read` and `Write` must never, ever, _ever_ be able to leave or be stored in the System. This is normally accomplished with the lifetime associated with the system itself. This could probably be patched by treating them as weak pointers to a specific generation of the collection of resources, and panic in case someone tried to use them if this generation has changed.

Some APIs have been completely butchered for their existing safety guarantees, and some safety holes are available as APIs. E.g. it's possible to discard and `SystemFetch` because that's needed to perform composition of fetches.

To wrap up: this is probably a terrible idea. It was fun to try out, but please don't merge :).