### PR TITLE
Remove `::` prefix from derived implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = ["shred-derive"]
 
 [dev-dependencies]
 cgmath = "0.16"
-shred-derive = { path = "shred-derive", version = "0.5.0" }
+shred-derive = { path = "shred-derive", version = "0.6.0" }
 
 [features]
 default = ["parallel"]

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -2,7 +2,7 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{DispatcherBuilder, Read, Resources, System, Write};
+use shred::{DispatcherBuilder, Read, ResourceId, Resources, System, SystemData, Write};
 
 #[derive(Debug, Default)]
 struct ResA;

--- a/examples/derive_bundle.rs
+++ b/examples/derive_bundle.rs
@@ -2,7 +2,7 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{Read, Resources, SystemData, Write};
+use shred::{Read, ResourceId, Resources, SystemData, Write};
 
 #[derive(Debug, Default)]
 struct ResA;

--- a/examples/generic_derive.rs
+++ b/examples/generic_derive.rs
@@ -6,7 +6,7 @@ extern crate shred_derive;
 
 use std::fmt::Debug;
 
-use shred::{Read, Resource, Write};
+use shred::{Read, Resource, ResourceId, Resources, SystemData, Write};
 
 trait Hrtb<'a> {}
 

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -2,7 +2,7 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{DispatcherBuilder, Read, Resources, System, Write};
+use shred::{DispatcherBuilder, Read, ResourceId, Resources, System, SystemData, Write};
 
 #[derive(Debug, Default)]
 struct ResA;

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -2,7 +2,7 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{DispatcherBuilder, Read, Resources, System, Write};
+use shred::{DispatcherBuilder, Read, ResourceId, Resources, System, SystemData, Write};
 
 #[derive(Debug, Default)]
 struct ResA;

--- a/shred-derive/Cargo.toml
+++ b/shred-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred-derive"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["torkleyy"]
 description = "Custom derive for shred"
 documentation = "https://docs.rs/shred_derive"

--- a/shred-derive/src/lib.rs
+++ b/shred-derive/src/lib.rs
@@ -50,35 +50,35 @@ fn impl_system_data(ast: &DeriveInput) -> proc_macro2::TokenStream {
 
     quote! {
         impl #impl_generics
-            ::shred::SystemData< #impl_fetch_lt >
+            shred::SystemData< #impl_fetch_lt >
             for #name #ty_generics #where_clause
         {
-            fn setup(res: &mut ::shred::Resources) {
+            fn setup(res: &mut shred::Resources) {
                 #(
-                    <#tys as ::shred::SystemData> :: setup(res);
+                    <#tys as shred::SystemData> :: setup(res);
                 )*
             }
 
-            fn fetch(res: & #impl_fetch_lt ::shred::Resources) -> Self {
+            fn fetch(res: & #impl_fetch_lt shred::Resources) -> Self {
                 #fetch_return
             }
 
-            fn reads() -> Vec<::shred::ResourceId> {
+            fn reads() -> Vec<shred::ResourceId> {
                 let mut r = Vec::new();
 
                 #( {
-                        let mut reads = <#tys as ::shred::SystemData> :: reads();
+                        let mut reads = <#tys as shred::SystemData> :: reads();
                         r.append(&mut reads);
                     } )*
 
                 r
             }
 
-            fn writes() -> Vec<::shred::ResourceId> {
+            fn writes() -> Vec<shred::ResourceId> {
                 let mut r = Vec::new();
 
                 #( {
-                        let mut writes = <#tys as ::shred::SystemData> :: writes();
+                        let mut writes = <#tys as shred::SystemData> :: writes();
                         r.append(&mut writes);
                     } )*
 
@@ -96,10 +96,10 @@ fn gen_identifiers(fields: &Punctuated<Field, Comma>) -> Vec<Ident> {
     fields.iter().map(|x| x.ident.clone().unwrap()).collect()
 }
 
-/// Adds a `::shred::SystemData<'lt>` bound on each of the system data types.
+/// Adds a `shred::SystemData<'lt>` bound on each of the system data types.
 fn constrain_system_data_types(clause: &mut WhereClause, fetch_lt: &Lifetime, tys: &[Type]) {
     for ty in tys.iter() {
-        let where_predicate: WherePredicate = parse_quote!(#ty : ::shred::SystemData< #fetch_lt >);
+        let where_predicate: WherePredicate = parse_quote!(#ty : shred::SystemData< #fetch_lt >);
         clause.predicates.push(where_predicate);
     }
 }
@@ -130,13 +130,13 @@ fn gen_from_body(ast: &Data, name: &Ident) -> (proc_macro2::TokenStream, Vec<Typ
 
             quote! {
                 #name {
-                    #( #identifiers: ::shred::SystemData::fetch(res) ),*
+                    #( #identifiers: shred::SystemData::fetch(res) ),*
                 }
             }
         }
         DataType::Tuple => {
             let count = tys.len();
-            let fetch = vec![quote! { ::shred::SystemData::fetch(res) }; count];
+            let fetch = vec![quote! { shred::SystemData::fetch(res) }; count];
 
             quote! {
                 #name ( #( #fetch ),* )

--- a/shred-derive/src/lib.rs
+++ b/shred-derive/src/lib.rs
@@ -50,35 +50,35 @@ fn impl_system_data(ast: &DeriveInput) -> proc_macro2::TokenStream {
 
     quote! {
         impl #impl_generics
-            shred::SystemData< #impl_fetch_lt >
+            SystemData< #impl_fetch_lt >
             for #name #ty_generics #where_clause
         {
-            fn setup(res: &mut shred::Resources) {
+            fn setup(res: &mut Resources) {
                 #(
-                    <#tys as shred::SystemData> :: setup(res);
+                    <#tys as SystemData> :: setup(res);
                 )*
             }
 
-            fn fetch(res: & #impl_fetch_lt shred::Resources) -> Self {
+            fn fetch(res: & #impl_fetch_lt Resources) -> Self {
                 #fetch_return
             }
 
-            fn reads() -> Vec<shred::ResourceId> {
+            fn reads() -> Vec<ResourceId> {
                 let mut r = Vec::new();
 
                 #( {
-                        let mut reads = <#tys as shred::SystemData> :: reads();
+                        let mut reads = <#tys as SystemData> :: reads();
                         r.append(&mut reads);
                     } )*
 
                 r
             }
 
-            fn writes() -> Vec<shred::ResourceId> {
+            fn writes() -> Vec<ResourceId> {
                 let mut r = Vec::new();
 
                 #( {
-                        let mut writes = <#tys as shred::SystemData> :: writes();
+                        let mut writes = <#tys as SystemData> :: writes();
                         r.append(&mut writes);
                     } )*
 
@@ -96,10 +96,10 @@ fn gen_identifiers(fields: &Punctuated<Field, Comma>) -> Vec<Ident> {
     fields.iter().map(|x| x.ident.clone().unwrap()).collect()
 }
 
-/// Adds a `shred::SystemData<'lt>` bound on each of the system data types.
+/// Adds a `SystemData<'lt>` bound on each of the system data types.
 fn constrain_system_data_types(clause: &mut WhereClause, fetch_lt: &Lifetime, tys: &[Type]) {
     for ty in tys.iter() {
-        let where_predicate: WherePredicate = parse_quote!(#ty : shred::SystemData< #fetch_lt >);
+        let where_predicate: WherePredicate = parse_quote!(#ty : SystemData< #fetch_lt >);
         clause.predicates.push(where_predicate);
     }
 }
@@ -130,13 +130,13 @@ fn gen_from_body(ast: &Data, name: &Ident) -> (proc_macro2::TokenStream, Vec<Typ
 
             quote! {
                 #name {
-                    #( #identifiers: shred::SystemData::fetch(res) ),*
+                    #( #identifiers: SystemData::fetch(res) ),*
                 }
             }
         }
         DataType::Tuple => {
             let count = tys.len();
-            let fetch = vec![quote! { shred::SystemData::fetch(res) }; count];
+            let fetch = vec![quote! { SystemData::fetch(res) }; count];
 
             quote! {
                 #name ( #( #fetch ),* )

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -2,9 +2,9 @@ use std::fmt;
 
 use fxhash::FxHashMap;
 
-use dispatch::Dispatcher;
 use dispatch::dispatcher::{SystemId, ThreadLocal};
 use dispatch::stage::StagesBuilder;
+use dispatch::Dispatcher;
 use system::{RunNow, System};
 
 /// Builder for the [`Dispatcher`].
@@ -27,7 +27,7 @@ use system::{RunNow, System};
 /// # extern crate shred;
 /// # #[macro_use]
 /// # extern crate shred_derive;
-/// # use shred::{Dispatcher, DispatcherBuilder, Read, System};
+/// # use shred::{Dispatcher, DispatcherBuilder, Read, ResourceId, Resources, System, SystemData};
 /// # #[derive(Debug, Default)] struct Res;
 /// # #[derive(SystemData)] #[allow(unused)] struct Data<'a> { a: Read<'a, Res> }
 /// # struct Dummy;
@@ -61,7 +61,7 @@ use system::{RunNow, System};
 /// # extern crate shred;
 /// # #[macro_use]
 /// # extern crate shred_derive;
-/// # use shred::{Dispatcher, DispatcherBuilder, Read, System};
+/// # use shred::{Dispatcher, DispatcherBuilder, Read, ResourceId, Resources, System, SystemData};
 /// # #[derive(Debug, Default)] struct Res;
 /// # #[derive(SystemData)] #[allow(unused)] struct Data<'a> { a: Read<'a, Res> }
 /// # struct Dummy;
@@ -150,9 +150,11 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
 
         let id = self.next_id();
 
-        let dependencies = dep.iter()
+        let dependencies = dep
+            .iter()
             .map(|x| {
-                *self.map
+                *self
+                    .map
                     .get(*x)
                     .expect(&format!("No such system registered (\"{}\")", *x))
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@
 //! #[macro_use]
 //! extern crate shred_derive;
 //!
-//! use shred::{DispatcherBuilder, Read, Resource, Resources, System, Write};
+//! use shred::{
+//!     DispatcherBuilder, Read, Resource, ResourceId, Resources, System, SystemData, Write
+//! };
 //!
 //! #[derive(Debug, Default)]
 //! struct ResA;
@@ -79,7 +81,11 @@ pub use dispatch::{Dispatcher, DispatcherBuilder};
 #[cfg(feature = "parallel")]
 pub use dispatch::{Par, ParSeq, RunWithPool, Seq};
 pub use meta::{CastFrom, MetaIter, MetaIterMut, MetaTable};
-pub use res::{DefaultProvider, Entry, Fetch, FetchMut, PanicHandler, Read, ReadExpect, Resource,
-              ResourceId, Resources, SetupHandler, Write, WriteExpect};
-pub use system::{Accessor, AccessorCow, RunNow, RunningTime, StaticAccessor, SystemData,
-                 System, DynamicSystemData};
+pub use res::{
+    DefaultProvider, Entry, Fetch, FetchMut, PanicHandler, Read, ReadExpect, Resource, ResourceId,
+    Resources, SetupHandler, Write, WriteExpect,
+};
+pub use system::{
+    Accessor, AccessorCow, DynamicSystemData, RunNow, RunningTime, StaticAccessor, System,
+    SystemData,
+};

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -2,7 +2,10 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{Dispatcher, DispatcherBuilder, Read, Resources, RunningTime, System, Write};
+use shred::{
+    Dispatcher, DispatcherBuilder, Read, ResourceId, Resources, RunningTime, System, SystemData,
+    Write,
+};
 
 fn sleep_short() {
     use std::thread::sleep;


### PR DESCRIPTION
This allows an in-scope re-exported `shred` crate to be used.

Closes #102

---

I'll test this in a larger project, give me a few days to get to it.