### PR TITLE
Update HashMaps to use hashbrown HashMap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache: cargo
 
 rust:
 - nightly
+- beta
+- stable
 - 1.30.0
 
 branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "torkleyy/shred" }
 
 [dependencies]
 arrayvec = "0.4"
-fxhash = "0.2"
+hashbrown = "0.1.7"
 mopa = "0.2"
 rayon = { version = "1.0", optional = true }
 smallvec = "0.6"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ MIT/Apache-2.
 
 ## License
 
-`shred` is distributed under the terms of both the MIT 
+`shred` is distributed under the terms of both the MIT
 license and the Apache License (Version 2.0).
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT).

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use fxhash::FxHashMap;
+use hashbrown::HashMap;
 
 use dispatch::dispatcher::{SystemId, ThreadLocal};
 use dispatch::stage::StagesBuilder;
@@ -89,7 +89,7 @@ use system::{RunNow, System};
 #[derive(Default)]
 pub struct DispatcherBuilder<'a, 'b> {
     current_id: usize,
-    map: FxHashMap<String, SystemId>,
+    map: HashMap<String, SystemId>,
     stages_builder: StagesBuilder<'a>,
     thread_local: ThreadLocal<'b>,
     #[cfg(feature = "parallel")]
@@ -146,7 +146,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     where
         T: for<'c> System<'c> + Send + 'a,
     {
-        use std::collections::hash_map::Entry;
+        use hashbrown::hash_map::Entry;
 
         let id = self.next_id();
 

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -33,7 +33,7 @@
 use std::fmt;
 
 use arrayvec::ArrayVec;
-use fxhash::FxHashMap;
+use hashbrown::HashMap;
 use smallvec::SmallVec;
 
 use dispatch::dispatcher::{SystemExecSend, SystemId};
@@ -177,9 +177,9 @@ impl<'a> StagesBuilder<'a> {
     pub fn write_par_seq(
         &self,
         f: &mut fmt::Formatter,
-        map: &FxHashMap<String, SystemId>,
+        map: &HashMap<String, SystemId>,
     ) -> fmt::Result {
-        let map: FxHashMap<_, _> = map.iter()
+        let map: HashMap<_, _> = map.iter()
             .map(|(key, value)| (*value, key as &str))
             .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 #![warn(missing_docs)]
 
 extern crate arrayvec;
-extern crate fxhash;
+extern crate hashbrown;
 #[macro_use]
 extern crate mopa;
 #[cfg(feature = "parallel")]

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 use std::marker::PhantomData;
 
-use fxhash::FxHashMap;
+use hashbrown::HashMap;
 use mopa::Any;
 
 use {Resource, World};
@@ -228,7 +228,7 @@ where
 /// ```
 pub struct MetaTable<T: ?Sized> {
     fat: Vec<Fat>,
-    indices: FxHashMap<TypeId, usize>,
+    indices: HashMap<TypeId, usize>,
     tys: Vec<TypeId>,
     // `MetaTable` is invariant over `T`
     marker: PhantomData<Invariant<T>>,
@@ -250,7 +250,7 @@ impl<T: ?Sized> MetaTable<T> {
         R: Resource,
         T: CastFrom<R> + 'static,
     {
-        use std::collections::hash_map::Entry;
+        use hashbrown::hash_map::Entry;
 
         let fat = unsafe { Fat::from_ptr(<T as CastFrom<R>>::cast(r)) };
 

--- a/src/res/entry.rs
+++ b/src/res/entry.rs
@@ -1,8 +1,9 @@
-use std::collections::hash_map::Entry as StdEntry;
 use std::marker::PhantomData;
 
 use cell::TrustCell;
 use res::{FetchMut, Resource, ResourceId};
+
+type StdEntry<'a, K, V> = hashbrown::hash_map::Entry<'a, K, V, hashbrown::hash_map::DefaultHashBuilder>;
 
 /// An entry to a resource of the `World` struct.
 /// This is similar to the Entry API found in the standard library.

--- a/src/res/mod.rs
+++ b/src/res/mod.rs
@@ -8,7 +8,7 @@ use std::any::TypeId;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
-use fxhash::FxHashMap;
+use hashbrown::HashMap;
 use mopa::Any;
 
 use self::entry::create_entry;
@@ -112,7 +112,7 @@ impl ResourceId {
 /// Resources are identified by `ResourceId`s, which consist of a `TypeId`.
 #[derive(Default)]
 pub struct World {
-    resources: FxHashMap<ResourceId, TrustCell<Box<Resource>>>,
+    resources: HashMap<ResourceId, TrustCell<Box<Resource>>>,
 }
 
 impl World {


### PR DESCRIPTION
A small update of the `FxHashMap` `HashMap` to use the more perfomante `hashbrown` `HashMap`.

[`hashbrown`](https://github.com/Amanieu/hashbrown) is a Rust port of Google's high-performance SwissTable hash map and is around [2 times faster](https://github.com/Amanieu/hashbrown#features) than `FxHashMap`.