### PR TITLE
[WIP] Remove System::setup

### DIFF
--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -27,11 +27,10 @@ impl<'a> System<'a> for PrintSystem {
 }
 
 fn main() {
-    let mut resources = Resources::new();
+    let resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
         .with(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();
-    dispatcher.setup(&mut resources);
 
     // Dispatch as often as you want to
     dispatcher.dispatch(&resources);

--- a/examples/dyn_sys_data.rs
+++ b/examples/dyn_sys_data.rs
@@ -83,10 +83,6 @@ impl<'a> System<'a> for DynamicSystem {
     fn accessor<'b>(&'b self) -> AccessorCow<'a, 'b, Self> {
         AccessorCow::Ref(&self.dependencies)
     }
-
-    fn setup(&mut self, _res: &mut Resources) {
-        // this could call a setup function of the script
-    }
 }
 
 /// Some trait that all of your dynamic resources should implement.
@@ -259,14 +255,12 @@ fn main() {
     }
 
     let mut dispatcher = DispatcherBuilder::new().with(NormalSys, "normal", &[]).build();
-    dispatcher.setup(&mut res);
 
     let script0 = create_script_sys(&res);
 
     // it is recommended you create a second dispatcher dedicated to scripts,
     // that'll allow you to rebuild if necessary
     let mut scripts = DispatcherBuilder::new().with(script0, "script0", &[]).build();
-    scripts.setup(&mut res);
 
     // Game loop
     loop {

--- a/examples/fetch_opt.rs
+++ b/examples/fetch_opt.rs
@@ -51,7 +51,6 @@ fn main() {
         .build();
 
     // Will automatically insert `ResB` (the only one that has a default provider).
-    dispatcher.setup(&mut resources);
     resources.insert(ResWithoutSensibleDefault {
         magic_number_that_we_cant_compute: 42,
     });

--- a/examples/par_seq.rs
+++ b/examples/par_seq.rs
@@ -60,7 +60,6 @@ fn main() {
         &pool,
     );
 
-    dispatcher.setup(&mut res);
     dispatcher.dispatch(&mut res);
 
     // If we want to generate this graph from a `DispatcherBuilder`,

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -28,11 +28,10 @@ impl<'a> System<'a> for EmptySystem {
 }
 
 fn main() {
-    let mut resources = Resources::new();
+    let resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
         .with(EmptySystem, "empty", &[])
         .build();
-    dispatcher.setup(&mut resources);
 
     dispatcher.dispatch_seq(&resources);
 }

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -30,11 +30,10 @@ impl<'a> System<'a> for EmptySystem {
 fn main() {
     let mut x = 5;
 
-    let mut resources = Resources::new();
+    let resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
         .with_thread_local(EmptySystem(&mut x))
         .build();
-    dispatcher.setup(&mut resources);
 
     dispatcher.dispatch(&resources);
 }

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -14,18 +14,6 @@ pub struct Dispatcher<'a, 'b> {
 }
 
 impl<'a, 'b> Dispatcher<'a, 'b> {
-    /// Sets up all the systems which means they are gonna add default values for the resources
-    /// they need.
-    pub fn setup(&mut self, res: &mut Resources) {
-        for stage in &mut self.stages {
-            stage.setup(res);
-        }
-
-        for sys in &mut self.thread_local {
-            sys.setup(res);
-        }
-    }
-
     /// Dispatch all the systems with given resources and context
     /// and then run thread local systems.
     ///
@@ -110,10 +98,6 @@ impl<'a, 'b> Dispatcher<'a, 'b> {
 impl<'a, 'b, 'c> RunNow<'a> for Dispatcher<'b, 'c> {
     fn run_now(&mut self, res: &Resources) {
         self.dispatch(res);
-    }
-
-    fn setup(&mut self, res: &mut Resources) {
-        self.setup(res);
     }
 }
 

--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -226,12 +226,6 @@ where
         ParSeq { run, pool }
     }
 
-    /// Sets up `res` for `dispatch`ing.
-    /// This will add default values for required resources by calling `System::setup`.
-    pub fn setup(&mut self, res: &mut Resources) {
-        self.run.setup(res);
-    }
-
     /// Dispatches the systems using `res`.
     /// This doesn't call any virtual functions.
     ///
@@ -250,18 +244,11 @@ where
     fn run_now(&mut self, res: &Resources) {
         RunWithPool::run(&mut self.run, res, self.pool.borrow());
     }
-
-    fn setup(&mut self, res: &mut Resources) {
-        RunWithPool::setup(&mut self.run, res);
-    }
 }
 
 /// Similar to `RunNow` except additionally taking in a rayon::ThreadPool
 /// for parallelism.
 pub trait RunWithPool<'a> {
-    /// Sets up `Resources` for a later call to `run`.
-    fn setup(&mut self, res: &mut Resources);
-
     /// Runs the system/group of systems. Possibly in parallel depending
     /// on how the structure is set up.
     ///
@@ -286,10 +273,6 @@ impl<'a, T> RunWithPool<'a> for T
 where
     T: System<'a>,
 {
-    fn setup(&mut self, res: &mut Resources) {
-        T::setup(self, res);
-    }
-
     fn run(&mut self, res: &'a Resources, _: &ThreadPool) {
         RunNow::run_now(self, res);
     }
@@ -311,11 +294,6 @@ where
     H: RunWithPool<'a> + Send,
     T: RunWithPool<'a> + Send,
 {
-    fn setup(&mut self, res: &mut Resources) {
-        self.head.setup(res);
-        self.tail.setup(res);
-    }
-
     fn run(&mut self, res: &'a Resources, pool: &ThreadPool) {
         let head = &mut self.head;
         let tail = &mut self.tail;
@@ -372,11 +350,6 @@ where
     H: RunWithPool<'a>,
     T: RunWithPool<'a>,
 {
-    fn setup(&mut self, res: &mut Resources) {
-        self.head.setup(res);
-        self.tail.setup(res);
-    }
-
     fn run(&mut self, res: &'a Resources, pool: &ThreadPool) {
         self.head.run(res, pool);
         self.tail.run(res, pool);

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -79,14 +79,6 @@ impl<'a> Stage<'a> {
         Default::default()
     }
 
-    pub fn setup(&mut self, res: &mut Resources) {
-        for group in &mut self.groups {
-            for sys in group {
-                sys.setup(res);
-            }
-        }
-    }
-
     #[cfg(feature = "parallel")]
     pub fn execute(&mut self, res: &Resources) {
         use rayon::prelude::*;

--- a/src/res/mod.rs
+++ b/src/res/mod.rs
@@ -254,7 +254,7 @@ impl Resources {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use {RunNow, System, SystemData};
+    use {SystemData};
 
     #[derive(Default)]
     struct Res;
@@ -310,31 +310,5 @@ mod tests {
 
         let write: FetchMut<Res> = res.fetch_mut();
         let read: Fetch<Res> = res.fetch();
-    }
-
-    #[test]
-    fn default_works() {
-        struct Sys;
-
-        impl<'a> System<'a> for Sys {
-            type SystemData = Write<'a, i32>;
-
-            fn run(&mut self, mut data: Self::SystemData) {
-                assert_eq!(*data, 0);
-
-                *data = 33;
-            }
-        }
-
-        let mut res = Resources::new();
-        assert!(res.try_fetch::<i32>().is_none());
-
-        let mut sys = Sys;
-        RunNow::setup(&mut sys, &mut res);
-
-        sys.run_now(&res);
-
-        assert!(res.try_fetch::<i32>().is_some());
-        assert_eq!(*res.fetch::<i32>(), 33);
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -111,9 +111,6 @@ pub trait RunNow<'a> {
     /// (tries to read from a resource which is already written to or
     /// tries to write to a resource which is read from).
     fn run_now(&mut self, res: &'a Resources);
-
-    /// Sets up `Resources` for a later call to `run_now`.
-    fn setup(&mut self, res: &mut Resources);
 }
 
 impl<'a, T> RunNow<'a> for T
@@ -123,10 +120,6 @@ where
     fn run_now(&mut self, res: &'a Resources) {
         let data = T::SystemData::fetch(&self.accessor(), res);
         self.run(data);
-    }
-
-    fn setup(&mut self, res: &mut Resources) {
-        T::setup(self, res);
     }
 }
 
@@ -172,11 +165,6 @@ pub trait System<'a> {
             AccessorTy::<'a, Self>::try_new()
                 .expect("Missing implementation for `accessor`"),
         )
-    }
-
-    /// Sets up the `Resources` using `Self::SystemData::setup`.
-    fn setup(&mut self, res: &mut Resources) {
-        <Self::SystemData as DynamicSystemData>::setup(&self.accessor(), res)
     }
 }
 


### PR DESCRIPTION
This is the first of a series of PRs in a process to remove `System::setup` and replace it with more organic methods of initializing systems. Mostly opening this to get feedback and to start thinking about better methods.

cc @torkleyy 

This is related to slide-rs/specs#532