### PR TITLE
Rename World::new to World::empty

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -184,7 +184,7 @@ fn basic(b: &mut Bencher) {
         // the integration
         .build();
 
-    let mut res = World::new();
+    let mut res = World::empty();
     let mass = VecStorage::new(Mass(10.0));
     let mut pos = VecStorage::new(Pos(Vec3::new(0.0, 0.0, 0.0)));
     let vel = VecStorage::new(Vel(Vec3::new(0.0, 0.0, 0.0)));
@@ -209,7 +209,7 @@ fn basic(b: &mut Bencher) {
 
 #[bench]
 fn bench_fetching(b: &mut Bencher) {
-    let mut world = World::new();
+    let mut world = World::empty();
 
     let mass = VecStorage::new(Mass(10.0));
     let mut pos = VecStorage::new(Pos(Vec3::new(0.0, 0.0, 0.0)));

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -46,7 +46,7 @@ impl<'a> System<'a> for PrintSystem {
 fn main() {
     let mut x = 5;
 
-    let mut resources = World::new();
+    let mut resources = World::empty();
     resources.insert(ResA);
     resources.insert(ResB);
     let mut dispatcher = DispatcherBuilder::new()

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -27,7 +27,7 @@ impl<'a> System<'a> for PrintSystem {
 }
 
 fn main() {
-    let mut resources = World::new();
+    let mut resources = World::empty();
     let mut dispatcher = DispatcherBuilder::new()
         .with(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();

--- a/examples/custom_bundle.rs
+++ b/examples/custom_bundle.rs
@@ -36,7 +36,7 @@ impl<'a> SystemData<'a> for ExampleBundle<'a> {
 }
 
 fn main() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(ResA);
     res.insert(ResB);
 

--- a/examples/derive_bundle.rs
+++ b/examples/derive_bundle.rs
@@ -23,7 +23,7 @@ struct Nested<'a> {
 }
 
 fn main() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(ResA);
     res.insert(ResB);
 

--- a/examples/dyn_sys_data.rs
+++ b/examples/dyn_sys_data.rs
@@ -249,7 +249,7 @@ fn main() {
         }
     }
 
-    let mut res = World::new();
+    let mut res = World::empty();
 
     {
         let mut table = res.entry().or_insert_with(|| ReflectionTable::new());

--- a/examples/dynamic_resource_id.rs
+++ b/examples/dynamic_resource_id.rs
@@ -82,7 +82,7 @@ impl ScriptingInterface {
 // -- Step 2 - Setup the World --
 
 fn setup_world() -> World {
-    let mut world = World::new();
+    let mut world = World::empty();
 
     let mut interface = ScriptingInterface::new();
 

--- a/examples/fetch_opt.rs
+++ b/examples/fetch_opt.rs
@@ -45,7 +45,7 @@ impl<'a> System<'a> for PrintSystem {
 }
 
 fn main() {
-    let mut resources = World::new();
+    let mut resources = World::empty();
     let mut dispatcher = DispatcherBuilder::new()
         .with(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .build();

--- a/examples/par_seq.rs
+++ b/examples/par_seq.rs
@@ -41,7 +41,7 @@ fn main() {
 
     let pool = ThreadPoolBuilder::new().build().expect("OS error");
 
-    let mut res = World::new();
+    let mut res = World::empty();
     let x = 5u8;
 
     let mut dispatcher = ParSeq::new(

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -28,7 +28,7 @@ impl<'a> System<'a> for EmptySystem {
 }
 
 fn main() {
-    let mut resources = World::new();
+    let mut resources = World::empty();
     let mut dispatcher = DispatcherBuilder::new()
         .with(EmptySystem, "empty", &[])
         .build();

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -30,7 +30,7 @@ impl<'a> System<'a> for EmptySystem {
 fn main() {
     let mut x = 5;
 
-    let mut resources = World::new();
+    let mut resources = World::empty();
     let mut dispatcher = DispatcherBuilder::new()
         .with_thread_local(EmptySystem(&mut x))
         .build();

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -212,7 +212,7 @@ mod tests {
     }
 
     fn new_world() -> World {
-        let mut world = World::new();
+        let mut world = World::empty();
         world.insert(Res(0));
 
         world

--- a/src/dispatch/par_seq.rs
+++ b/src/dispatch/par_seq.rs
@@ -184,7 +184,7 @@ impl<H> Par<H, Nil> {
 /// #
 /// # let pool = ThreadPool::new(Default::default()).unwrap();
 /// #
-/// # let mut world = World::new();
+/// # let mut world = World::empty();
 /// let x = 5u8;
 ///
 /// let mut dispatcher = ParSeq::new(
@@ -429,11 +429,11 @@ mod tests {
         Par::new(A(nr.clone()))
             .with(A(nr.clone()))
             .with(A(nr.clone()))
-            .run(&World::new(), &pool);
+            .run(&World::empty(), &pool);
 
         assert_eq!(nr.load(Ordering::Acquire), 3);
 
-        par![A(nr.clone()), A(nr.clone()),].run(&World::new(), &pool);
+        par![A(nr.clone()), A(nr.clone()),].run(&World::empty(), &pool);
 
         assert_eq!(nr.load(Ordering::Acquire), 5);
     }
@@ -457,7 +457,7 @@ mod tests {
         Seq::new(A(nr.clone()))
             .with(A(nr.clone()))
             .with(A(nr.clone()))
-            .run(&World::new(), &pool);
+            .run(&World::empty(), &pool);
 
         assert_eq!(nr.load(Ordering::Acquire), 3);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! }
 //!
 //! fn main() {
-//!     let mut world = World::new();
+//!     let mut world = World::empty();
 //!     let mut dispatcher = DispatcherBuilder::new()
 //!         .with(EmptySystem, "empty", &[])
 //!         .build();

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -213,7 +213,7 @@ where
 ///     }
 /// }
 ///
-/// let mut world = World::new();
+/// let mut world = World::empty();
 ///
 /// world.insert(ImplementorA(3));
 /// world.insert(ImplementorB(1));
@@ -399,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_iter_all() {
-        let mut world = World::new();
+        let mut world = World::empty();
 
         world.insert(ImplementorA(3));
         world.insert(ImplementorB(1));
@@ -427,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_iter_all_after_removal() {
-        let mut world = World::new();
+        let mut world = World::empty();
 
         world.insert(ImplementorA(3));
         world.insert(ImplementorB(1));
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn get() {
-        let mut world = World::new();
+        let mut world = World::empty();
 
         world.insert(ImplementorC);
         world.insert(ImplementorD);

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -19,7 +19,7 @@ type StdEntry<'a, K, V> =
 /// #[derive(Debug)]
 /// struct Res(i32);
 ///
-/// let mut world = World::new();
+/// let mut world = World::empty();
 ///
 /// let value = world.entry().or_insert(Res(4));
 /// println!("{:?}", value.0 * 2);
@@ -74,7 +74,7 @@ mod tests {
     fn test_entry() {
         struct Res;
 
-        let mut world = World::new();
+        let mut world = World::empty();
         world.entry().or_insert(Res);
 
         assert!(world.has_value::<Res>());

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -188,7 +188,7 @@ impl World {
     /// # #[derive(Debug)] struct MyRes(i32);
     /// use shred::World;
     ///
-    /// let mut world = World::new();
+    /// let mut world = World::empty();
     /// world.insert(MyRes(5));
     /// ```
     pub fn insert<R>(&mut self, r: R)
@@ -417,7 +417,7 @@ mod tests {
         assert_eq!(Read::<Res>::reads(), vec![ResourceId::new::<Res>()]);
         assert_eq!(Read::<Res>::writes(), vec![]);
 
-        let mut world = World::new();
+        let mut world = World::empty();
         world.insert(Res);
         <Read<Res> as SystemData>::fetch(&world);
     }
@@ -427,14 +427,14 @@ mod tests {
         assert_eq!(Write::<Res>::reads(), vec![]);
         assert_eq!(Write::<Res>::writes(), vec![ResourceId::new::<Res>()]);
 
-        let mut world = World::new();
+        let mut world = World::empty();
         world.insert(Res);
         <Write<Res> as SystemData>::fetch(&world);
     }
 
     #[test]
     fn fetch_by_id() {
-        let mut world = World::new();
+        let mut world = World::empty();
 
         world.insert_by_id(ResourceId::new_with_dynamic_id::<i32>(1), 5);
         world.insert_by_id(ResourceId::new_with_dynamic_id::<i32>(2), 15);
@@ -463,7 +463,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_fetch_by_id0() {
-        let mut world = World::new();
+        let mut world = World::empty();
 
         world.insert(5i32);
 
@@ -473,7 +473,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_fetch_by_id1() {
-        let mut world = World::new();
+        let mut world = World::empty();
 
         world.insert(5i32);
 
@@ -484,7 +484,7 @@ mod tests {
     fn add() {
         struct Foo;
 
-        let mut world = World::new();
+        let mut world = World::empty();
         world.insert(Res);
 
         assert!(world.has_value::<Res>());
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Already borrowed")]
     fn read_write_fails() {
-        let mut world = World::new();
+        let mut world = World::empty();
         world.insert(Res);
 
         let read: Fetch<Res> = world.fetch();
@@ -506,7 +506,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Already borrowed mutably")]
     fn write_read_fails() {
-        let mut world = World::new();
+        let mut world = World::empty();
         world.insert(Res);
 
         let write: FetchMut<Res> = world.fetch_mut();
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn remove_insert() {
-        let mut world = World::new();
+        let mut world = World::empty();
 
         world.insert(Res);
 
@@ -546,7 +546,7 @@ mod tests {
             }
         }
 
-        let mut world = World::new();
+        let mut world = World::empty();
         assert!(world.try_fetch::<i32>().is_none());
 
         let mut sys = Sys;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -162,7 +162,9 @@ pub struct World {
 
 impl World {
     /// Creates a new, empty resource container.
-    pub fn new() -> Self {
+    ///
+    /// Note that if you're using Specs, you should use `WorldExt::new` instead.
+    pub fn empty() -> Self {
         Default::default()
     }
 

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -77,7 +77,7 @@ fn dispatch_builder_invalid() {
 
 #[test]
 fn dispatch_basic() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
 
     let number = 5;
@@ -93,7 +93,7 @@ fn dispatch_basic() {
 
 #[test]
 fn dispatch_ww_block() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
@@ -106,7 +106,7 @@ fn dispatch_ww_block() {
 
 #[test]
 fn dispatch_rw_block() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
@@ -119,7 +119,7 @@ fn dispatch_rw_block() {
 
 #[test]
 fn dispatch_rw_block_rev() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
@@ -132,7 +132,7 @@ fn dispatch_rw_block_rev() {
 
 #[test]
 fn dispatch_sequential() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
 
     let mut d: Dispatcher = DispatcherBuilder::new()
@@ -146,7 +146,7 @@ fn dispatch_sequential() {
 #[cfg(feature = "parallel")]
 #[test]
 fn dispatch_async() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
 
     let mut d = DispatcherBuilder::new()
@@ -162,7 +162,7 @@ fn dispatch_async() {
 #[cfg(feature = "parallel")]
 #[test]
 fn dispatch_async_res() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
 
     let mut d = DispatcherBuilder::new()
@@ -178,7 +178,7 @@ fn dispatch_async_res() {
 
 #[test]
 fn dispatch_stage_group() {
-    let mut res = World::new();
+    let mut res = World::empty();
     res.insert(Res);
     res.insert(ResB);
 

--- a/tests/dispose.rs
+++ b/tests/dispose.rs
@@ -20,7 +20,7 @@ impl<'a> System<'a> for Sys {
 
 #[test]
 fn test_dispose() {
-    let mut world = World::new();
+    let mut world = World::empty();
 
     let mut dispatcher = DispatcherBuilder::new().with(Sys, "sys", &[]).build();
 

--- a/tests/nightly.rs
+++ b/tests/nightly.rs
@@ -9,7 +9,7 @@ struct MyRes;
 #[test]
 #[should_panic(expected = "Tried to fetch a resource of type \"MyRes\"")]
 fn try_helpful_panic() {
-    let res = World::new();
+    let res = World::empty();
 
     let _expect: ReadExpect<MyRes> = SystemData::fetch(&res);
 }


### PR DESCRIPTION
This allows to avoid confusion with the `WorldExt::new`
from Specs