### PR TITLE
Make Fetch cloneable

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -233,6 +233,16 @@ mod tests {
     }
 
     #[test]
+    fn allow_clone_reads() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let a = cell.borrow();
+        let b = a.clone();
+
+        assert_eq!(10, *a + *b);
+    }
+
+    #[test]
     fn allow_single_write() {
         let cell: TrustCell<_> = TrustCell::new(5);
 
@@ -302,6 +312,17 @@ mod tests {
         let cell: TrustCell<_> = TrustCell::new(5);
 
         let _a = cell.try_borrow().unwrap();
+
+        assert!(cell.try_borrow_mut().is_err());
+    }
+
+    #[test]
+    fn cloned_borrow_does_not_allow_write() {
+        let cell: TrustCell<_> = TrustCell::new(5);
+
+        let a = cell.borrow();
+        let _b = a.clone();
+        drop(a);
 
         assert!(cell.try_borrow_mut().is_err());
     }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -49,6 +49,16 @@ impl<'a, T> Drop for Ref<'a, T> {
     }
 }
 
+impl<'a, T> Clone for Ref<'a, T> {
+    fn clone(&self) -> Self {
+        self.flag.fetch_add(1, Ordering::SeqCst);
+        Ref {
+            flag: self.flag,
+            value: self.value,
+        }
+    }
+}
+
 /// A mutable reference to data in a `TrustCell`.
 ///
 /// Access the value via `std::ops::DerefMut` (e.g. `*val`)

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -51,7 +51,7 @@ impl<'a, T> Drop for Ref<'a, T> {
 
 impl<'a, T> Clone for Ref<'a, T> {
     fn clone(&self) -> Self {
-        self.flag.fetch_add(1, Ordering::SeqCst);
+        self.flag.fetch_add(1, Ordering::Release);
         Ref {
             flag: self.flag,
             value: self.value,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -47,6 +47,15 @@ where
     }
 }
 
+impl<'a, T> Clone for Fetch<'a, T> {
+    fn clone(&self) -> Self {
+        Fetch {
+            inner: self.inner.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 /// Allows to fetch a resource in a system mutably.
 ///
 /// If the resource isn't strictly required, you should use


### PR DESCRIPTION
Working on allowing [gluon](https://github.com/gluon-lang/gluon) to work with specs/shred and ended up needing to clone some `Fetch<EntitiesRes>` values. I don't know fully how specs/shred work internally but this should be equivalent to doing multiple `fetch` operations and should therefore be sound.