### PR TITLE
Remove box indirection in `Fetch{,Mut}`

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -35,6 +35,73 @@ pub struct Ref<'a, T: 'a + ?Sized> {
     value: &'a T,
 }
 
+impl<'a, T: ?Sized> Ref<'a, T> {
+    /// Makes a new `Ref` for a component of the borrowed data which preserves
+    /// the existing borrow.
+    ///
+    /// The `TrustCell` is already immutably borrowed, so this cannot fail.
+    ///
+    /// This is an associated function that needs to be used as `Ref::map(...)`.
+    /// A method would interfere with methods of the same name on the contents
+    /// of a `Ref` used through `Deref`. Further this preserves the borrow of
+    /// the value and hence does the proper cleanup when it's dropped.
+    ///
+    /// # Examples
+    ///
+    /// This can be used to avoid pointer indirection when a boxed item is
+    /// stored in the `TrustCell`.
+    ///
+    /// ```
+    /// use shred::cell::{Ref, TrustCell};
+    ///
+    /// let cb = TrustCell::new(Box::new(5));
+    ///
+    /// // Borrowing the cell causes the `Ref` to store a reference to the `Box`, which is a
+    /// // pointer to the value on the heap, not the actual value.
+    /// let boxed_ref: Ref<'_, Box<usize>> = cb.borrow();
+    /// assert_eq!(**boxed_ref, 5); // Notice the double deref to get the actual value.
+    ///
+    /// // By using `map` we can let `Ref` store a reference directly to the value on the heap.
+    /// let pure_ref: Ref<'_, usize> = Ref::map(boxed_ref, Box::as_ref);
+    ///
+    /// assert_eq!(*pure_ref, 5);
+    /// ```
+    ///
+    /// We can also use `map` to get a reference to a sub-part of the borrowed
+    /// value.
+    ///
+    /// ```rust
+    /// # use shred::cell::{TrustCell, Ref};
+    ///
+    /// let c = TrustCell::new((5, 'b'));
+    /// let b1: Ref<'_, (u32, char)> = c.borrow();
+    /// let b2: Ref<'_, u32> = Ref::map(b1, |t| &t.0);
+    /// assert_eq!(*b2, 5);
+    /// ```
+    pub fn map<U, F>(self, f: F) -> Ref<'a, U>
+    where
+        F: FnOnce(&T) -> &U,
+        U: ?Sized,
+    {
+        // Extract the values from the `Ref` through a pointer so that we do not run
+        // `Drop`. Because the returned `Ref` has the same lifetime `'a` as the
+        // given `Ref`, the lifetime we created through turning the pointer into
+        // a ref is valid.
+        let flag = unsafe { &*(self.flag as *const _) };
+        let value = unsafe { &*(self.value as *const _) };
+
+        // We have to forget self so that we do not run `Drop`. Further it's safe
+        // because we are creating a new `Ref`, with the same flag, which will
+        // run the cleanup when it's dropped.
+        std::mem::forget(self);
+
+        Ref {
+            flag,
+            value: f(value),
+        }
+    }
+}
+
 impl<'a, T: ?Sized> Deref for Ref<'a, T> {
     type Target = T;
 
@@ -66,6 +133,75 @@ impl<'a, T: ?Sized> Clone for Ref<'a, T> {
 pub struct RefMut<'a, T: 'a + ?Sized> {
     flag: &'a AtomicUsize,
     value: &'a mut T,
+}
+
+impl<'a, T: ?Sized> RefMut<'a, T> {
+    /// Makes a new `RefMut` for a component of the borrowed data which
+    /// preserves the existing borrow.
+    ///
+    /// The `TrustCell` is already mutably borrowed, so this cannot fail.
+    ///
+    /// This is an associated function that needs to be used as
+    /// `RefMut::map(...)`. A method would interfere with methods of the
+    /// same name on the contents of a `RefMut` used through `DerefMut`.
+    /// Further this preserves the borrow of the value and hence does the
+    /// proper cleanup when it's dropped.
+    ///
+    /// # Examples
+    ///
+    /// This can also be used to avoid pointer indirection when a boxed item is
+    /// stored in the `TrustCell`.
+    ///
+    /// ```
+    /// use shred::cell::{RefMut, TrustCell};
+    ///
+    /// let cb = TrustCell::new(Box::new(5));
+    ///
+    /// // Borrowing the cell causes the `RefMut` to store a reference to the `Box`, which is a
+    /// // pointer to the value on the heap, and not a reference directly to the value.
+    /// let boxed_ref: RefMut<'_, Box<usize>> = cb.borrow_mut();
+    /// assert_eq!(**boxed_ref, 5); // Notice the double deref to get the actual value.
+    ///
+    /// // By using `map` we can let `RefMut` store a reference directly to the value on the heap.
+    /// let pure_ref: RefMut<'_, usize> = RefMut::map(boxed_ref, Box::as_mut);
+    ///
+    /// assert_eq!(*pure_ref, 5);
+    /// ```
+    ///
+    /// We can also use `map` to get a reference to a sub-part of the borrowed
+    /// value.
+    ///
+    /// ```rust
+    /// # use shred::cell::{TrustCell, RefMut};
+    ///
+    /// let c = TrustCell::new((5, 'b'));
+    ///
+    /// let b1: RefMut<'_, (u32, char)> = c.borrow_mut();
+    /// let b2: RefMut<'_, u32> = RefMut::map(b1, |t| &mut t.0);
+    /// assert_eq!(*b2, 5);
+    /// ```
+    pub fn map<U, F>(self, f: F) -> RefMut<'a, U>
+    where
+        F: FnOnce(&mut T) -> &mut U,
+        U: ?Sized,
+    {
+        // Extract the values from the `RefMut` through a pointer so that we do not run
+        // `Drop`. Because the returned `RefMut` has the same lifetime `'a` as
+        // the given `RefMut`, the lifetime we created through turning the
+        // pointer into a ref is valid.
+        let flag = unsafe { &*(self.flag as *const _) };
+        let value = unsafe { &mut *(self.value as *mut _) };
+
+        // We have to forget self so that we do not run `Drop`. Further it's safe
+        // because we are creating a new `RefMut`, with the same flag, which
+        // will run the cleanup when it's dropped.
+        std::mem::forget(self);
+
+        RefMut {
+            flag,
+            value: f(value),
+        }
+    }
 }
 
 impl<'a, T: ?Sized> Deref for RefMut<'a, T> {
@@ -382,4 +518,91 @@ mod tests {
         assert_eq!(ra.downcast_mut::<i32>().unwrap(), &mut 2i32);
     }
 
+    #[test]
+    fn ref_map_box() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: Ref<'_, Box<usize>> = cell.borrow();
+        assert_eq!(&**r, &10);
+
+        let rr: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+        assert_eq!(&*rr, &10);
+    }
+
+    #[test]
+    fn ref_map_preserves_flag() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: Ref<'_, Box<usize>> = cell.borrow();
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+        let _nr: Ref<'_, usize> = r.map(Box::as_ref);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn ref_map_retains_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let _r: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+
+        let _rr: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn ref_map_drops_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: Ref<'_, usize> = cell.borrow().map(Box::as_ref);
+
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 1);
+        drop(r);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn ref_mut_map_box() {
+        let cell = TrustCell::new(Box::new(10));
+
+        {
+            let mut r: RefMut<'_, Box<usize>> = cell.borrow_mut();
+            assert_eq!(&mut **r, &mut 10);
+        }
+        {
+            let mut rr: RefMut<'_, usize> = cell.borrow_mut().map(Box::as_mut);
+            assert_eq!(&mut *rr, &mut 10);
+        }
+    }
+
+    #[test]
+    fn ref_mut_map_preserves_flag() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: RefMut<'_, Box<usize>> = cell.borrow_mut();
+        assert_eq!(cell.flag.load(Ordering::SeqCst), std::usize::MAX);
+        let _nr: RefMut<'_, usize> = r.map(Box::as_mut);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), std::usize::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "Already borrowed")]
+    fn ref_mut_map_retains_mut_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let _rr: RefMut<'_, usize> = cell.borrow_mut().map(Box::as_mut);
+
+        let _ = cell.borrow_mut();
+    }
+
+    #[test]
+    fn ref_mut_map_drops_borrow() {
+        let cell = TrustCell::new(Box::new(10));
+
+        let r: RefMut<'_, usize> = cell.borrow_mut().map(Box::as_mut);
+
+        assert_eq!(cell.flag.load(Ordering::SeqCst), std::usize::MAX);
+        drop(r);
+        assert_eq!(cell.flag.load(Ordering::SeqCst), 0);
+    }
 }

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{
-    cell::TrustCell,
+    cell::{RefMut, TrustCell},
     world::{FetchMut, Resource, ResourceId},
 };
 
@@ -50,7 +50,7 @@ where
         let value = self
             .inner
             .or_insert_with(move || TrustCell::new(Box::new(f())));
-        let inner = value.borrow_mut();
+        let inner = RefMut::map(value.borrow_mut(), Box::as_mut);
 
         FetchMut {
             inner,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -32,7 +32,7 @@ mod setup;
 ///
 /// * `T`: The type of the resource
 pub struct Fetch<'a, T: 'a> {
-    inner: Ref<'a, Box<Resource>>,
+    inner: Ref<'a, dyn Resource>,
     phantom: PhantomData<&'a T>,
 }
 
@@ -65,7 +65,7 @@ impl<'a, T> Clone for Fetch<'a, T> {
 ///
 /// * `T`: The type of the resource
 pub struct FetchMut<'a, T: 'a> {
-    inner: RefMut<'a, Box<Resource>>,
+    inner: RefMut<'a, dyn Resource>,
     phantom: PhantomData<&'a mut T>,
 }
 
@@ -274,7 +274,7 @@ impl World {
         let res_id = ResourceId::new::<T>();
 
         self.resources.get(&res_id).map(|r| Fetch {
-            inner: r.borrow(),
+            inner: Ref::map(r.borrow(), Box::as_ref),
             phantom: PhantomData,
         })
     }
@@ -295,7 +295,7 @@ impl World {
         id.assert_same_type_id::<T>();
 
         self.resources.get(&id).map(|r| Fetch {
-            inner: r.borrow(),
+            inner: Ref::map(r.borrow(), Box::as_ref),
             phantom: PhantomData,
         })
     }
@@ -324,7 +324,7 @@ impl World {
         let res_id = ResourceId::new::<T>();
 
         self.resources.get(&res_id).map(|r| FetchMut {
-            inner: r.borrow_mut(),
+            inner: RefMut::map(r.borrow_mut(), Box::as_mut),
             phantom: PhantomData,
         })
     }
@@ -345,7 +345,7 @@ impl World {
         id.assert_same_type_id::<T>();
 
         self.resources.get(&id).map(|r| FetchMut {
-            inner: r.borrow_mut(),
+            inner: RefMut::map(r.borrow_mut(), Box::as_mut),
             phantom: PhantomData,
         })
     }


### PR DESCRIPTION
I know that `cell` is a small part of this library that is not really meant for consumption. However upon closer inspection, in my process to learn amethyst, I figured that I might have a change that could cause a tiny performance improvement that hopefully would ripple through-out all consumers of this library. 

## Situation

The existing implementation of `Ref{,Mut}` had the implicit bound `T: Sized`. However internally the `T` was stored behind a reference, which means that it doesn't need to be sized to make `Ref{,Mut}` a sized struct. By removing this bound we can make `T` a `dyn Resource` instead of a `Box<Resource>`, which means that we remove a layer of indirection. This means that instead of having a `Fetch{,Mut}` with a `Ref{,Mut}<'_, Box<Resource>>`, we can rather give it `Ref{,Mut}<'_, dyn Resource>`.

## Solution

To accomplish this I defined `map` on `Ref{,Mut}` (as is implemented in std for `Ref{,Mut}` of `RefCell`) so that one could modify the contents of `Ref{,Mut}`. That way one can work around the fact that the `T` in `TrustCell` has to be sized, by rather changing the reference after it's creation. 

## Performance

I ran the benchmarks in the repo to see a small performance _increase_ in the `basic` case. 

##### Box-indirection (before)

```
test basic          ... bench:       9,152 ns/iter (+/- 90)
test bench_fetching ... bench:       4,602 ns/iter (+/- 7)
```

##### Direct reference (after)

```
test basic                  ... bench:       8,510 ns/iter (+/- 60)
test bench_fetching         ... bench:       4,608 ns/iter (+/- 95)
```

----

Further I added two benchmarks which also highlight the difference.

##### Comparison when accessing value of Ref multiple times

```
test bench_direct_refs      ... bench:       5,010 ns/iter (+/- 50)
test bench_indirection_refs ... bench:       6,618 ns/iter (+/- 182)
```