### PR TITLE
Move methods from `specs::WorldExt` to `World`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["torkleyy <torkleyy@gmail.com>"]
 description = """
 Dispatches systems in parallel which need read access to some resources,

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -30,7 +30,7 @@ impl Error for InvalidBorrow {
 ///
 /// Access the value via `std::ops::Deref` (e.g. `*val`)
 #[derive(Debug)]
-pub struct Ref<'a, T: 'a + ?Sized> {
+pub struct Ref<'a, T: ?Sized + 'a> {
     flag: &'a AtomicUsize,
     value: &'a T,
 }
@@ -130,7 +130,7 @@ impl<'a, T: ?Sized> Clone for Ref<'a, T> {
 ///
 /// Access the value via `std::ops::DerefMut` (e.g. `*val`)
 #[derive(Debug)]
-pub struct RefMut<'a, T: 'a + ?Sized> {
+pub struct RefMut<'a, T: ?Sized + 'a> {
     flag: &'a AtomicUsize,
     value: &'a mut T,
 }

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -183,7 +183,8 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     ///
     /// Thread-local systems are dispatched in-order.
     ///
-    /// Same as [DispatcherBuilder::add_thread_local], but returns `self` to enable method chaining.
+    /// Same as [DispatcherBuilder::add_thread_local], but returns `self` to
+    /// enable method chaining.
     pub fn with_thread_local<T>(mut self, system: T) -> Self
     where
         T: for<'c> RunNow<'c> + 'b,
@@ -215,7 +216,8 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     /// Thread-local systems are not affected by barriers;
     /// they're always executed at the end.
     ///
-    /// Same as [DispatcherBuilder::add_barrier], but returns `self` to enable method chaining.
+    /// Same as [DispatcherBuilder::add_barrier], but returns `self` to enable
+    /// method chaining.
     pub fn with_barrier(mut self) -> Self {
         self.add_barrier();
 

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -183,9 +183,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     ///
     /// Thread-local systems are dispatched in-order.
     ///
-    /// Same as
-    /// [`add_thread_local()`](struct.DispatcherBuilder.html#method.
-    /// add_thread_local), but returns `self` to enable method chaining.
+    /// Same as [DispatcherBuilder::add_thread_local], but returns `self` to enable method chaining.
     pub fn with_thread_local<T>(mut self, system: T) -> Self
     where
         T: for<'c> RunNow<'c> + 'b,
@@ -217,9 +215,7 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     /// Thread-local systems are not affected by barriers;
     /// they're always executed at the end.
     ///
-    /// Same as
-    /// [`add_barrier()`](struct.DispatcherBuilder.html#method.add_barrier),
-    /// but returns `self` to enable method chaining.
+    /// Same as [DispatcherBuilder::add_barrier], but returns `self` to enable method chaining.
     pub fn with_barrier(mut self) -> Self {
         self.add_barrier();
 

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -43,16 +43,13 @@ impl<'a, 'b> Dispatcher<'a, 'b> {
     ///
     /// This function automatically redirects to
     ///
-    /// * [`dispatch_par`] in case it is supported
-    /// * [`dispatch_seq`] otherwise
+    /// * [Dispatcher::dispatch_par] in case it is supported
+    /// * [Dispatcher::dispatch_seq] otherwise
     ///
     /// and runs `dispatch_thread_local` afterwards.
     ///
     /// Please note that this method assumes that no resource
     /// is currently borrowed. If that's the case, it panics.
-    ///
-    /// [`dispatch_par`]: struct.Dispatcher.html#method.dispatch_par
-    /// [`dispatch_seq`]: struct.Dispatcher.html#method.dispatch_seq
     pub fn dispatch(&mut self, world: &World) {
         #[cfg(feature = "parallel")]
         self.dispatch_par(world);

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -3,7 +3,7 @@ use std::{any::TypeId, marker::PhantomData};
 use hashbrown::HashMap;
 use mopa::Any;
 
-use crate::{Resource, World, ResourceId};
+use crate::{Resource, ResourceId, World};
 
 /// This implements `Send` and `Sync` unconditionally.
 /// (the trait itself doesn't need to have these bounds and the
@@ -435,7 +435,6 @@ mod tests {
         let mut table = MetaTable::<Object>::new();
         table.register(&ImplementorA(125));
         table.register(&ImplementorB(111111));
-
 
         {
             let mut iter = table.iter(&mut world);

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -616,6 +616,60 @@ mod tests {
     }
 
     #[test]
+    fn system_data() {
+        let mut world = World::empty();
+
+        world.insert(5u32);
+        let x = *world.system_data::<Read<u32>>();
+        assert_eq!(x, 5);
+    }
+
+    #[test]
+    fn setup() {
+        let mut world = World::empty();
+
+        world.insert(5u32);
+        world.setup::<Read<u32>>();
+        let x = *world.system_data::<Read<u32>>();
+        assert_eq!(x, 5);
+
+        world.remove::<u32>();
+        world.setup::<Read<u32>>();
+        let x = *world.system_data::<Read<u32>>();
+        assert_eq!(x, 0);
+    }
+
+    #[test]
+    fn exec() {
+        let mut world = World::empty();
+
+        world.exec(|(float, boolean): (Read<f32>, Read<bool>)| {
+            assert_eq!(*float, 0.0);
+            assert_eq!(*boolean, false);
+        });
+
+        world.exec(|(mut float, mut boolean): (Write<f32>, Write<bool>)| {
+            *float = 4.3;
+            *boolean = true;
+        });
+
+        world.exec(|(float, boolean): (Read<f32>, ReadExpect<bool>)| {
+            assert_eq!(*float, 4.3);
+            assert_eq!(*boolean, true);
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn exec_panic() {
+        let mut world = World::empty();
+
+        world.exec(|(_float, _boolean): (Write<f32>, Write<bool>)| {
+            panic!();
+        });
+    }
+
+    #[test]
     #[should_panic]
     fn invalid_fetch_by_id0() {
         let mut world = World::empty();


### PR DESCRIPTION
Also bumped to 0.9.0 due to recent breaking change (#138).